### PR TITLE
update TRANSPORT_SERVICE for compatibility

### DIFF
--- a/src/upnp_transport.c
+++ b/src/upnp_transport.c
@@ -48,7 +48,7 @@
 #include "upnp_transport.h"
 
 //#define TRANSPORT_SERVICE "urn:upnp-org:serviceId:AVTransport"
-#define TRANSPORT_SERVICE "urn:schemas-upnp-org:service:AVTransport"
+#define TRANSPORT_SERVICE "urn:schemas-upnp-org:service:AVTransport:1"
 #define TRANSPORT_TYPE "urn:schemas-upnp-org:service:AVTransport:1"
 #define TRANSPORT_SCPD_URL "/upnp/rendertransportSCPD.xml"
 #define TRANSPORT_CONTROL_URL "/upnp/control/rendertransport1"


### PR DESCRIPTION
Update service type to make action results work with platinum sdk (http://sourceforge.net/projects/platinum/).  

Not sure if this is a bug, or if version 1 is just a newer version.  Couldn't find any documents referencing an earlier version. 

The only av transport spec I found used the urn:schemas-upnp-org:service:AVTransport:1 format
http://upnp.org/specs/av/UPnP-av-AVTransport-v1-Service.pdf
