### PR TITLE
Do not overwrite CFLAGS and CXXFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,8 +20,8 @@ EXTRA_GCC_DEBUG_CXXFLAGS=""
 if test -n "$GCC"; then
    EXTRA_GCC_DEBUG_CFLAGS="$CFLAGS"
    EXTRA_GCC_DEBUG_CXXFLAGS="$CXXFLAGS"
-   CFLAGS="-Wall -Wpointer-arith -Wmissing-prototypes -Wmissing-declarations -Wwrite-strings"
-   CXXFLAGS="-Wall -Wpointer-arith"
+   CFLAGS+=" -Wall -Wpointer-arith -Wmissing-prototypes -Wmissing-declarations -Wwrite-strings"
+   CXXFLAGS+=" -Wall -Wpointer-arith"
 fi  
 
 AC_CHECK_FUNCS([asprintf])


### PR DESCRIPTION
Hallo,

during packaging gmrender, I saw that this little issue. Maybe you want to fix this :)
The overwriting of the C*FLAGS makes it for example harder to package a "hardened" version as required parameters are not passed on properly, leading to build failures....

Thanks

https://wiki.debian.org/Hardening
