### PR TITLE
configure --without-gstreamer caused failure of make

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -44,7 +44,9 @@
 
 // For version strings of upnp and gstreamer
 #include <upnp/upnpconfig.h>
+#ifdef HAVE_GST
 #include <gst/gst.h>
+#endif
 
 #include "git-version.h"
 #include "logging.h"
@@ -169,11 +171,20 @@ static void log_variable_change(void *userdata, int var_num,
 
 static void init_logging(const char *log_file) {
 	char version[1024];
+
+	#ifdef HAVE_GST
 	snprintf(version, sizeof(version), "[ gmediarender %s "
 		 "(libupnp-%s; glib-%d.%d.%d; gstreamer-%d.%d.%d) ]",
 		 GM_COMPILE_VERSION, UPNP_VERSION_STRING,
 		 GLIB_MAJOR_VERSION, GLIB_MINOR_VERSION, GLIB_MICRO_VERSION,
 		 GST_VERSION_MAJOR, GST_VERSION_MINOR, GST_VERSION_MICRO);
+	#else
+	snprintf(version, sizeof(version), "[ gmediarender %s "
+		 "(libupnp-%s; glib-%d.%d.%d; without gstreamer.) ]",
+		 GM_COMPILE_VERSION, UPNP_VERSION_STRING,
+		 GLIB_MAJOR_VERSION, GLIB_MINOR_VERSION, GLIB_MICRO_VERSION);
+	#endif
+
 	if (log_file != NULL) {
 		Log_init(log_file);
 		Log_info("main", "%s log started %s", PACKAGE_STRING, version);


### PR DESCRIPTION
this tiny commit fixes the issue that make will fail if I configure the project
with --without-gstreamer option enabled.