### PR TITLE
fix bug due to the unescaped quote

### DIFF
--- a/dist-scripts/debian/gmrender-resurrect.service
+++ b/dist-scripts/debian/gmrender-resurrect.service
@@ -4,7 +4,7 @@ After=network.target sound.target
 
 [Service]
 Environment="UPNP_DEVICE_NAME=Raspberry"
-ExecStartPre=/bin/sh -c "/bin/systemctl set-environment UPNP_UUID=`ip link show | awk '/ether/ {print "salt:)-" $2}' | head -1 | md5sum | awk '{print $1}'`"
+ExecStartPre=/bin/sh -c "/bin/systemctl set-environment UPNP_UUID=`ip link show | awk '/ether/ {print \"salt:)-\" $2}' | head -1 | md5sum | awk '{print $1}'`"
 
 ExecStart=/usr/local/bin/gmediarender -f "$UPNP_DEVICE_NAME" -u "$UPNP_UUID" \
                                       --gstout-audiosink=alsasink --gstout-audiodevice=sysdefault \


### PR DESCRIPTION
It failed when I try to set gmrender on startup by systemd, and I got the error message below:

  Process: 12440 ExecStartPre=/bin/sh -c /bin/systemctl set-environment UPNP_UUID=`ip link show | awk '/ether/ {print  salt:)-" $2}' | head -1 | md5sum | awk {print $1} `" (code=exited, status=2)

This is caused by the unescaped quote.