### PR TITLE
Fix spelling: s/inital/initial

### DIFF
--- a/src/output_gstreamer.c
+++ b/src/output_gstreamer.c
@@ -395,7 +395,7 @@ static GOptionEntry option_entries[] = {
 	  "(autovideosink, xvimagesink, ximagesink, ...)",
 	  NULL },
         { "gstout-initial-volume-db", 0, 0, G_OPTION_ARG_DOUBLE, &initial_db,
-          "GStreamer inital volume in decibel (e.g. 0.0 = max; -6 = 1/2 max) ",
+          "GStreamer initial volume in decibel (e.g. 0.0 = max; -6 = 1/2 max) ",
 	  NULL },
         { NULL }
 };

--- a/src/upnp_control.c
+++ b/src/upnp_control.c
@@ -793,7 +793,7 @@ void upnp_control_init(struct upnp_device *device) {
 	// Set initial volume.
 	float volume_fraction = 0;
 	if (output_get_volume(&volume_fraction) == 0) {
-		Log_info("control", "Output inital volume is %f; setting "
+		Log_info("control", "Output initial volume is %f; setting "
 			 "control variables accordingly.", volume_fraction);
 		change_volume_decibel(20 * log(volume_fraction) / log(10));
 	}


### PR DESCRIPTION
A small typo, found by Debian's lintian.