### PR TITLE
Add filtering of top-level MIME types to advertise.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -82,6 +82,7 @@ static const gchar *friendly_name = PACKAGE_NAME;
 static const gchar *output = NULL;
 static const gchar *pid_file = NULL;
 static const gchar *log_file = NULL;
+static const gchar *mime_filter = NULL;
 
 /* Generic GMediaRender options */
 static GOptionEntry option_entries[] = {
@@ -105,6 +106,8 @@ static GOptionEntry option_entries[] = {
 	  "File the process ID should be written to.", NULL },
 	{ "daemon", 'd', 0, G_OPTION_ARG_NONE, &daemon_mode,
 	  "Run as daemon.", NULL },
+	{ "mime-filter", 0, 0, G_OPTION_ARG_STRING, &mime_filter,
+	  "MIME type filter to apply to advertized support.", NULL },
 	{ "logfile", 0, 0, G_OPTION_ARG_STRING, &log_file,
 	  "Debug log filename. Use /dev/stdout to log to console.", NULL },
 	{ "list-outputs", 0, 0, G_OPTION_ARG_NONE, &show_outputs,
@@ -259,6 +262,8 @@ int main(int argc, char **argv)
 	if (upnp_renderer == NULL) {
 		return EXIT_FAILURE;
 	}
+
+	upnp_renderer_set_mime_filter(mime_filter);
 
 	rc = output_init(output);
 	if (rc != 0) {

--- a/src/main.c
+++ b/src/main.c
@@ -107,7 +107,7 @@ static GOptionEntry option_entries[] = {
 	{ "daemon", 'd', 0, G_OPTION_ARG_NONE, &daemon_mode,
 	  "Run as daemon.", NULL },
 	{ "mime-filter", 0, 0, G_OPTION_ARG_STRING, &mime_filter,
-	  "MIME type filter to apply to advertized support.", NULL },
+	  "Top-level MIME type to advertize support for. e.g. audio,video,image", NULL },
 	{ "logfile", 0, 0, G_OPTION_ARG_STRING, &log_file,
 	  "Debug log filename. Use /dev/stdout to log to console.", NULL },
 	{ "list-outputs", 0, 0, G_OPTION_ARG_NONE, &show_outputs,

--- a/src/main.c
+++ b/src/main.c
@@ -107,7 +107,7 @@ static GOptionEntry option_entries[] = {
 	{ "daemon", 'd', 0, G_OPTION_ARG_NONE, &daemon_mode,
 	  "Run as daemon.", NULL },
 	{ "mime-filter", 0, 0, G_OPTION_ARG_STRING, &mime_filter,
-	  "Top-level MIME type to advertize support for. e.g. audio,video,image", NULL },
+	  "Top-level MIME type to advertise support for. e.g. audio,video,image", NULL },
 	{ "logfile", 0, 0, G_OPTION_ARG_STRING, &log_file,
 	  "Debug log filename. Use /dev/stdout to log to console.", NULL },
 	{ "list-outputs", 0, 0, G_OPTION_ARG_NONE, &show_outputs,

--- a/src/upnp_connmgr.c
+++ b/src/upnp_connmgr.c
@@ -249,7 +249,20 @@ void register_mime_type(const char *mime_type) {
 	}
 }
 
-int connmgr_init(void) {
+static int filter_mime_type(const char* filterList, const char* mime_type) {
+	// Make a modifiable copy of the mime type
+	int length = strcspn(mime_type, "/");
+	char* type = malloc(length + 2); // For slash and terminating 0
+	strncpy(type, mime_type, length + 1);
+	type[length + 1] = 0;
+
+	if (strstr(filterList, type) == NULL)
+		return 1;
+
+	return 0;
+}
+
+int connmgr_init(const char* filter) {
 	struct mime_type *entry;
 	char *buf = NULL;
 	char *p;
@@ -268,6 +281,11 @@ int connmgr_init(void) {
 	}
 
 	for (entry = supported_types; entry; entry = entry->next) {
+		
+		// Filter mime types
+		if (filter != NULL && filter_mime_type(filter, entry->mime_type))
+			continue;
+
 		bufsize += strlen(entry->mime_type) + 1 + 8 + 3 + 2;
 		offset = p - buf;
 		buf = realloc(buf, bufsize);

--- a/src/upnp_connmgr.c
+++ b/src/upnp_connmgr.c
@@ -252,9 +252,9 @@ void register_mime_type(const char *mime_type) {
 static int filter_mime_type(const char* filterList, const char* mime_type) {
 	// Make a modifiable copy of the mime type
 	int length = strcspn(mime_type, "/");
-	char* type = malloc(length + 2); // For slash and terminating 0
-	strncpy(type, mime_type, length + 1);
-	type[length + 1] = 0;
+	char* type = malloc(length + 1); // For terminating 0
+	strncpy(type, mime_type, length);
+	type[length] = 0;
 
 	if (strstr(filterList, type) == NULL)
 		return 1;

--- a/src/upnp_connmgr.c
+++ b/src/upnp_connmgr.c
@@ -251,15 +251,20 @@ void register_mime_type(const char *mime_type) {
 
 static int filter_mime_type(const char* filterList, const char* mime_type) {
 	// Make a modifiable copy of the mime type
-	int length = strcspn(mime_type, "/");
-	char* type = malloc(length + 1); // For terminating 0
-	strncpy(type, mime_type, length);
-	type[length] = 0;
+	char* type = malloc(strlen(mime_type) + 1);
+	if (type == NULL)
+		return 0;
 
-	if (strstr(filterList, type) == NULL)
-		return 1;
+	strcpy(type, mime_type);
 
-	return 0;
+	// Fetch the base type
+	char* base = strtok(type, "/");
+
+	// Check for base type in filter
+	int result = (strstr(filterList, base) == NULL);
+
+	free(type);
+	return result;
 }
 
 int connmgr_init(const char* filter) {

--- a/src/upnp_connmgr.h
+++ b/src/upnp_connmgr.h
@@ -25,7 +25,7 @@
 #define _UPNP_CONNMGR_H
 
 struct service *upnp_connmgr_get_service(void);
-int connmgr_init(void);
+int connmgr_init(const char* filter);
 
 void register_mime_type(const char *mime_type);
 

--- a/src/upnp_device.h
+++ b/src/upnp_device.h
@@ -39,6 +39,7 @@ struct upnp_device_descriptor {
         const char *udn;
         const char *upc;
         const char *presentation_url;
+	const char *mime_filter;
 	struct icon **icons;
 	struct service **services;
 };

--- a/src/upnp_renderer.c
+++ b/src/upnp_renderer.c
@@ -121,7 +121,7 @@ static int upnp_renderer_init(void)
 	upnp_services[2] = upnp_control_get_service();
 	upnp_services[3] = NULL;
 	render_device.services = upnp_services;
-        return connmgr_init();
+        return connmgr_init(render_device.mime_filter);
 }
 
 struct upnp_device_descriptor *
@@ -135,4 +135,9 @@ upnp_renderer_descriptor(const char *friendly_name,
 		render_device.udn = udn;
 	}
 	return &render_device;
+}
+
+void upnp_renderer_set_mime_filter(const char* filter)
+{
+	render_device.mime_filter = filter;
 }

--- a/src/upnp_renderer.h
+++ b/src/upnp_renderer.h
@@ -27,6 +27,7 @@
 void upnp_renderer_dump_connmgr_scpd(void);
 void upnp_renderer_dump_control_scpd(void);
 void upnp_renderer_dump_transport_scpd(void);
+void upnp_renderer_set_mime_filter(const char* filter);
 
 // Returned pointer not owned.
 struct upnp_device_descriptor *upnp_renderer_descriptor(const char *name,


### PR DESCRIPTION
Adds an command line argument to filter top-level MIME types to advertise. e.g. An audio-only setup shouldn't offer video playback support