### PR TITLE
Added proper support for buffering

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -104,7 +104,7 @@ Say, you want to use an ALSA device. You can see the available devices
 with `aplay -L`. The main ALSA device is typically called `sysdefault`,
 so this is how you select it on the command line:
 
-    gmediarenderer --gstout-audiosink=alsasink --gstout-audiodevice=sysdefault
+    gmediarender --gstout-audiosink=alsasink --gstout-audiodevice=sysdefault
 
 The options are described with
 

--- a/src/output_gstreamer.c
+++ b/src/output_gstreamer.c
@@ -363,8 +363,20 @@ static gboolean my_bus_callback(GstBus * bus, GstMessage * msg,
 	}
 
 	case GST_MESSAGE_BUFFERING:
-		/* not caring about these right now */
+        {
+                gint percent = 0;
+                gst_message_parse_buffering (msg, &percent);
+
+                /* Maybe make an option, to disable buffering for
+                 * live-streams */
+
+                /* Pause playback until buffering is complete. */
+                if (percent < 100)
+                        gst_element_set_state(player_, GST_STATE_PAUSED);
+                else
+                        gst_element_set_state(player_, GST_STATE_PLAYING);
 		break;
+        }
 	default:
 		/*
 		g_print("GStreamer: %s: unhandled message type %d (%s)\n",

--- a/src/output_gstreamer.c
+++ b/src/output_gstreamer.c
@@ -40,6 +40,8 @@
 #include "output_module.h"
 #include "output_gstreamer.h"
 
+static double buffer_duration = 1.0; /* Buffer one second by default. */
+
 static void scan_caps(const GstCaps * caps)
 {
 	guint i;
@@ -367,8 +369,8 @@ static gboolean my_bus_callback(GstBus * bus, GstMessage * msg,
                 gint percent = 0;
                 gst_message_parse_buffering (msg, &percent);
 
-                /* Maybe make an option, to disable buffering for
-                 * live-streams */
+                /* check if buffering is disabled */
+                if (buffer_duration <= 0) break;
 
                 /* Pause playback until buffering is complete. */
                 if (percent < 100)
@@ -406,6 +408,9 @@ static GOptionEntry option_entries[] = {
           "GStreamer video sink to use "
 	  "(autovideosink, xvimagesink, ximagesink, ...)",
 	  NULL },
+        { "gstout-buffer-duration", 0, 0, G_OPTION_ARG_DOUBLE, &buffer_duration,
+          "The size of the buffer in seconds. Set to zero to disable buffering.",
+          NULL },
         { "gstout-initial-volume-db", 0, 0, G_OPTION_ARG_DOUBLE, &initial_db,
           "GStreamer initial volume in decibel (e.g. 0.0 = max; -6 = 1/2 max) ",
 	  NULL },
@@ -513,6 +518,20 @@ static int output_gstreamer_init(void)
 
 	player_ = gst_element_factory_make(player_element_name, "play");
 	assert(player_ != NULL);
+
+        /* set buffer size */
+        if (buffer_duration > 0) {
+                gint64 buffer_duration_ns = round(buffer_duration * 1.0e9);
+                Log_info("gstreamer",
+                         "Setting buffer duration to %ldms",
+                         buffer_duration_ns / 1000000);
+                g_object_set(G_OBJECT(player_),
+                             "buffer-duration",
+                             buffer_duration_ns,
+                             NULL);
+        } else {
+                Log_info("gstreamer", "Buffering disabled");
+        }
 
 	bus = gst_pipeline_get_bus(GST_PIPELINE(player_));
 	gst_bus_add_watch(bus, my_bus_callback, NULL);


### PR DESCRIPTION
When using gmediarender I often experience some stuttering of the audio at the beginning of some playback. This patch adds proper buffer handling and fixes the undesired behavior.