### PR TITLE
mpg123 output module

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -82,6 +82,42 @@ fi
 AC_SUBST(HAVE_GST)
 AM_CONDITIONAL(HAVE_GST, test x$HAVE_GST = xyes)
 
+AC_ARG_WITH( mpg123,
+  AC_HELP_STRING([--without-mpg123],[compile without mpg123 support]),
+  try_mpg123=$withval, try_mpg123=yes )
+HAVE_MPG123=no
+if test x$try_mpg123 = xyes; then
+  dnl check for mpg123
+  PKG_CHECK_MODULES(MPG123, libmpg123,
+    [
+      HAVE_MPG123=yes
+      AC_SUBST(MPG123_CFLAGS)
+      AC_SUBST(MPG123_LIBS)
+    ],
+    [
+      HAVE_MPG123=no
+    ])
+fi
+if test x$HAVE_MPG123 = xyes; then
+  AC_DEFINE(HAVE_MPG123, , [Use mpg123])
+fi
+AC_SUBST(HAVE_MPG123)
+AM_CONDITIONAL(HAVE_MPG123, test x$HAVE_MPG123 = xyes)
+
+if test x$HAVE_MPG123 = xyes; then
+  PKG_CHECK_MODULES(ALSA, alsa,
+    [
+      HAVE_ALSA=yes
+      AC_SUBST(ALSA_CFLAGS)
+      AC_SUBST(ALSA_LIBS)
+    ],
+    HAVE_ALSA=no)
+fi
+if test x$HAVE_ALSA = xyes; then
+  AC_DEFINE(HAVE_ALSA, , [Use alsa])
+fi
+AC_SUBST(HAVE_ALSA)
+AM_CONDITIONAL(HAVE_ALSA, test x$HAVE_ALSA = xyes)
 
 LIBUPNP_REQUIRED=1.6.0
 AC_ARG_WITH( libupnp,

--- a/configure.ac
+++ b/configure.ac
@@ -36,7 +36,27 @@ fi
 
 PKG_PROG_PKG_CONFIG
 
-PKG_CHECK_MODULES(GLIB, glib-2.0 gthread-2.0, HAVE_GLIB=yes, HAVE_GLIB=no)
+AC_ARG_WITH( glib,
+  AC_HELP_STRING([--without-glib],[compile without Glib support]),
+  try_glib=$withval, try_glib=yes )
+HAVE_GLIB=no
+if test x$try_glib = xyes; then
+  dnl check for Glib
+  PKG_CHECK_MODULES(GLIB, glib-2.0 gthread-2.0, 
+      [
+      HAVE_GLIB=yes
+      AC_SUBST(GLIB_CFLAGS)
+      AC_SUBST(GLIB_LIBS)
+
+    ],
+	HAVE_GLIB=no)
+fi
+if test x$HAVE_GLIB = xyes; then
+  AC_DEFINE(HAVE_GLIB, , [Use Glib])
+fi
+AC_SUBST(HAVE_GLIB)
+AM_CONDITIONAL(HAVE_GLIB, test x$HAVE_GLIB = xyes)
+
 
 # This is a bit crude, someone with more configure-fu please fix :)
 # We want either the new, or if that fails, the old version of gstreamer.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,7 @@
 bin_PROGRAMS = gmediarender
 
 gmediarender_SOURCES = main.c git-version.h \
+	output_module.c output_module.h \
 	upnp.c upnp_control.c upnp_connmgr.c  upnp_transport.c \
 	upnp.h upnp_control.h upnp_connmgr.h  upnp_transport.h \
 	song-meta-data.h song-meta-data.c \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,6 +19,18 @@ gmediarender_SOURCES += \
 	output_gstreamer.c  output_gstreamer.h
 endif
 
+if HAVE_MPG123
+gmediarender_SOURCES += \
+	output_mpg123.c  output_mpg123.h \
+	sound_module.c sound_module.h \
+	webclient.c webclient.h
+
+if HAVE_ALSA
+gmediarender_SOURCES += \
+	sound_alsa.c
+endif
+endif
+
 main.c : git-version.h
 
 git-version.h: .FORCE
@@ -28,5 +40,5 @@ git-version.h: .FORCE
 
 .FORCE:
 
-AM_CPPFLAGS = $(GLIB_CFLAGS) $(GST_CFLAGS) $(LIBUPNP_CFLAGS) -DPKG_DATADIR=\"$(datadir)/gmediarender\"
-gmediarender_LDADD = $(GLIB_LIBS) $(GST_LIBS) $(LIBUPNP_LIBS) 
+AM_CPPFLAGS = $(GLIB_CFLAGS) $(GST_CFLAGS) $(LIBUPNP_CFLAGS) $(MPG123_CFLAGS) $(ALSA_CFLAGS) -DPKG_DATADIR=\"$(datadir)/gmediarender\"
+gmediarender_LDADD = $(GLIB_LIBS) $(GST_LIBS) $(LIBUPNP_LIBS) $(MPG123_LIBS) $(ALSA_LIBS)

--- a/src/main.c
+++ b/src/main.c
@@ -58,32 +58,32 @@
 #include "upnp_renderer.h"
 #include "upnp_transport.h"
 
-static gboolean show_version = FALSE;
-static gboolean show_devicedesc = FALSE;
-static gboolean show_connmgr_scpd = FALSE;
-static gboolean show_control_scpd = FALSE;
-static gboolean show_transport_scpd = FALSE;
-static gboolean show_outputs = FALSE;
-static gboolean daemon_mode = FALSE;
+static int show_version = FALSE;
+static int show_devicedesc = FALSE;
+static int show_connmgr_scpd = FALSE;
+static int show_control_scpd = FALSE;
+static int show_transport_scpd = FALSE;
+static int show_outputs = FALSE;
+static int daemon_mode = FALSE;
 
 // IP-address seems strange in libupnp: they actually don't bind to
 // that address, but to INADDR_ANY (miniserver.c in upnp library).
 // Apparently they just use this for the advertisement ? Anyway, 0.0.0.0 would
 // not work.
-static const gchar *ip_address = NULL;
+static const char *ip_address = NULL;
 static int listen_port = 49494;
 
 #ifdef GMRENDER_UUID
 // Compile-time uuid.
-static const gchar *uuid = GMRENDER_UUID;
+static const char *uuid = GMRENDER_UUID;
 #else
-static const gchar *uuid = "GMediaRender-1_0-000-000-002";
+static const char *uuid = "GMediaRender-1_0-000-000-002";
 #endif
-static const gchar *friendly_name = PACKAGE_NAME;
-static const gchar *output = NULL;
-static const gchar *pid_file = NULL;
-static const gchar *log_file = NULL;
-static const gchar *mime_filter = NULL;
+static const char *friendly_name = PACKAGE_NAME;
+static const char *output = NULL;
+static const char *pid_file = NULL;
+static const char *log_file = NULL;
+static const char *mime_filter = NULL;
 
 /* Generic GMediaRender options */
 static GOptionEntry option_entries[] = {
@@ -135,7 +135,7 @@ static void do_show_version(void)
 	);
 }
 
-static gboolean process_cmdline(int argc, char **argv)
+static int process_cmdline(int argc, char **argv)
 {
 	GOptionContext *ctx;
 	GError *err = NULL;

--- a/src/main.c
+++ b/src/main.c
@@ -51,6 +51,7 @@
 #include "git-version.h"
 #include "logging.h"
 #include "output.h"
+#include "output_module.h"
 #include "upnp.h"
 #include "upnp_control.h"
 #include "upnp_device.h"
@@ -143,7 +144,7 @@ static gboolean process_cmdline(int argc, char **argv)
 	ctx = g_option_context_new("- GMediaRender");
 	g_option_context_add_main_entries(ctx, option_entries, NULL);
 
-	rc = output_add_options(ctx);
+	rc = output_module_add_goptions(ctx);
 	if (rc != 0) {
 		fprintf(stderr, "Failed to add output options\n");
 		return FALSE;
@@ -202,7 +203,6 @@ static void init_logging(const char *log_file) {
 
 int main(int argc, char **argv)
 {
-	int rc;
 	struct upnp_device_descriptor *upnp_renderer;
 
 #if !GLIB_CHECK_VERSION(2,32,0)
@@ -231,7 +231,7 @@ int main(int argc, char **argv)
 	}
 
 	if (show_outputs) {
-		output_dump_modules();
+		output_module_dump_modules();
 		exit(EXIT_SUCCESS);
 	}
 
@@ -265,11 +265,18 @@ int main(int argc, char **argv)
 
 	upnp_renderer_set_mime_filter(mime_filter);
 
-	rc = output_init(output);
-	if (rc != 0) {
-		Log_error("main",
-			  "ERROR: Failed to initialize Output subsystem");
-		return EXIT_FAILURE;
+	const struct output_module *module = output_module_get(output);
+	if (module != NULL) {
+		int rc;
+		rc = output_init(module);
+		if (rc != 0) {
+			Log_error("main",
+				  "ERROR: Failed to initialize Output subsystem");
+			return EXIT_FAILURE;
+		}
+	} else {
+		Log_error("error", "ERROR: No such output module: '%s'",
+			  output);
 	}
 
 	struct upnp_device *device;

--- a/src/main.c
+++ b/src/main.c
@@ -176,18 +176,24 @@ static void log_variable_change(void *userdata, int var_num,
 static void init_logging(const char *log_file) {
 	char version[1024];
 
+	snprintf(version, sizeof(version), "[ gmediarender %s "
+		 "(libupnp-%s; glib-%d.%d.%d; "
 #ifdef HAVE_GST
-	snprintf(version, sizeof(version), "[ gmediarender %s "
-		 "(libupnp-%s; glib-%d.%d.%d; gstreamer-%d.%d.%d) ]",
-		 GM_COMPILE_VERSION, UPNP_VERSION_STRING,
-		 GLIB_MAJOR_VERSION, GLIB_MINOR_VERSION, GLIB_MICRO_VERSION,
-		 GST_VERSION_MAJOR, GST_VERSION_MINOR, GST_VERSION_MICRO);
-#else
-	snprintf(version, sizeof(version), "[ gmediarender %s "
-		 "(libupnp-%s; glib-%d.%d.%d; without gstreamer.) ]",
-		 GM_COMPILE_VERSION, UPNP_VERSION_STRING,
-		 GLIB_MAJOR_VERSION, GLIB_MINOR_VERSION, GLIB_MICRO_VERSION);
+		 "gstreamer-%d.%d.%d; "
 #endif
+#ifdef HAVE_MPG123
+		 "mpg123-%d.%s.%s; "
+#endif
+			" ) ]",
+		 GM_COMPILE_VERSION, UPNP_VERSION_STRING
+		 ,GLIB_MAJOR_VERSION, GLIB_MINOR_VERSION, GLIB_MICRO_VERSION
+#ifdef HAVE_GST
+		 ,GST_VERSION_MAJOR, GST_VERSION_MINOR, GST_VERSION_MICRO
+#endif
+#ifdef HAVE_MPG123
+		 ,1, "2X", "Y"
+#endif
+		 );
 
 	if (log_file != NULL) {
 		Log_init(log_file);

--- a/src/output.c
+++ b/src/output.c
@@ -92,14 +92,14 @@ int output_stop(void) {
 	return -1;
 }
 
-int output_seek(gint64 position_nanos) {
+int output_seek(int64_t position_nanos) {
 	if (output_module && output_module->seek) {
 		return output_module->seek(position_nanos);
 	}
 	return -1;
 }
 
-int output_get_position(gint64 *track_dur, gint64 *track_pos) {
+int output_get_position(int64_t *track_dur, int64_t *track_pos) {
 	if (output_module && output_module->get_position) {
 		return output_module->get_position(track_dur, track_pos);
 	}

--- a/src/output.h
+++ b/src/output.h
@@ -24,7 +24,6 @@
 #ifndef _OUTPUT_H
 #define _OUTPUT_H
 
-#include <glib.h>
 #include "song-meta-data.h"
 
 struct output_module;
@@ -51,8 +50,8 @@ void output_set_next_uri(const char *uri);
 int output_play(output_transition_cb_t done_callback);
 int output_stop(void);
 int output_pause(void);
-int output_get_position(gint64 *track_dur_nanos, gint64 *track_pos_nanos);
-int output_seek(gint64 position_nanos);
+int output_get_position(int64_t *track_dur_nanos, int64_t *track_pos_nanos);
+int output_seek(int64_t position_nanos);
 
 int output_get_volume(float *v);
 int output_set_volume(float v);

--- a/src/output.h
+++ b/src/output.h
@@ -27,6 +27,8 @@
 #include <glib.h>
 #include "song-meta-data.h"
 
+struct output_module;
+
 // Feedback for the controlling part what is happening with the
 // output.
 enum PlayFeedback {
@@ -39,9 +41,7 @@ typedef void (*output_transition_cb_t)(enum PlayFeedback);
 // callback with changes we send back to the controlling layer.
 typedef void (*output_update_meta_cb_t)(const struct SongMetaData *);
 
-int output_init(const char *shortname);
-int output_add_options(GOptionContext *ctx);
-void output_dump_modules(void);
+int output_init(const struct output_module *module);
 
 int output_loop(void);
 

--- a/src/output_gstreamer.c
+++ b/src/output_gstreamer.c
@@ -28,6 +28,8 @@
 #include "config.h"
 #endif
 
+#include <glib.h>
+
 #include <assert.h>
 #include <gst/gst.h>
 #include <math.h>

--- a/src/output_gstreamer.c
+++ b/src/output_gstreamer.c
@@ -618,7 +618,7 @@ static int output_gstreamer_loop(void)
         return 0;
 }
 
-struct output_module gstreamer_output = {
+const struct output_module gstreamer_output = {
         .shortname = "gst",
 	.description = "GStreamer multimedia framework",
 	.init        = output_gstreamer_init,

--- a/src/output_module.c
+++ b/src/output_module.c
@@ -1,0 +1,107 @@
+/* output_module.c - Output module frontend
+ *
+ * Copyright (C) 2014-2019 Marc Chalain
+ *
+ * This file is part of GMediaRender.
+ *
+ * uplaymusic is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * uplaymusic is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GMediaRender; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA 02110-1301, USA.
+ *
+ */ 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <signal.h>
+
+#include "logging.h"
+#include "output_module.h"
+#ifdef HAVE_GST
+#include "output_gstreamer.h"
+#endif
+#ifdef HAVE_MPG123
+#include "output_mpg123.h"
+#endif
+#include "output.h"
+
+static const struct output_module *modules[] = {
+#ifdef HAVE_GST
+	&gstreamer_output,
+#endif
+};
+
+void output_module_dump_modules(void)
+{
+	int count;
+	
+	count = sizeof(modules) / sizeof(struct output_module *);
+	if (count == 0) {
+		puts("  NONE!");
+	} else {
+		int i;
+		for (i=0; i<count; i++) {
+			printf("Available output: %s\t%s%s\n",
+			       modules[i]->shortname,
+			       modules[i]->description,
+			       (i==0) ? " (default)" : "");
+		}
+	}
+}
+
+const struct output_module *output_module_get(const char *shortname)
+{
+	const struct output_module *output_module = NULL;
+	int count;
+
+	count = sizeof(modules) / sizeof(struct output_module *);
+	if (count == 0) {
+		Log_error("output", "No output module available");
+		return NULL;
+	}
+	if (shortname == NULL) {
+		output_module = modules[0];
+	} else {
+		int i;
+		for (i=0; i<count; i++) {
+			if (strcmp(modules[i]->shortname, shortname)==0) {
+				Log_info("output_module", "get %s",modules[i]->shortname);
+				output_module = modules[i];
+				break;
+			}
+		}
+	}
+	
+	return output_module;
+}
+
+int output_module_add_goptions(GOptionContext *ctx)
+{
+	int count, i;
+
+	count = sizeof(modules) / sizeof(struct output_module *);
+	for (i = 0; i < count; ++i) {
+		if (modules[i]->add_goptions) {
+			int result = modules[i]->add_goptions(ctx);
+			if (result != 0) {
+				return result;
+			}
+		}
+	}
+	return 0;
+}

--- a/src/output_module.c
+++ b/src/output_module.c
@@ -93,6 +93,7 @@ const struct output_module *output_module_get(const char *shortname)
 	return output_module;
 }
 
+#ifdef HAVE_GLIB
 int output_module_add_goptions(GOptionContext *ctx)
 {
 	int count, i;
@@ -108,3 +109,4 @@ int output_module_add_goptions(GOptionContext *ctx)
 	}
 	return 0;
 }
+#endif

--- a/src/output_module.c
+++ b/src/output_module.c
@@ -44,6 +44,9 @@ static const struct output_module *modules[] = {
 #ifdef HAVE_GST
 	&gstreamer_output,
 #endif
+#ifdef HAVE_MPG123
+	&mpg123_output,
+#endif
 };
 
 void output_module_dump_modules(void)

--- a/src/output_module.h
+++ b/src/output_module.h
@@ -26,6 +26,8 @@
 
 #include "output.h"
 
+typedef struct _GOptionContext GOptionContext;
+
 struct output_module {
         const char *shortname;
         const char *description;
@@ -39,10 +41,10 @@ struct output_module {
 	int (*stop)(void);
 	int (*pause)(void);
 	int (*loop)(void);
-	int (*seek)(gint64 position_nanos);
+	int (*seek)(int64_t position_nanos);
 
 	// parameters
-	int (*get_position)(gint64 *track_duration, gint64 *track_pos);
+	int (*get_position)(int64_t *track_duration, int64_t *track_pos);
 	int (*get_volume)(float *);
 	int (*set_volume)(float);
 	int (*get_mute)(int *);

--- a/src/output_module.h
+++ b/src/output_module.h
@@ -29,7 +29,7 @@
 struct output_module {
         const char *shortname;
         const char *description;
-	int (*add_options)(GOptionContext *ctx);
+	int (*add_goptions)(GOptionContext *ctx);
 
 	// Commands.
 	int (*init)(void);
@@ -48,6 +48,11 @@ struct output_module {
 	int (*get_mute)(int *);
 	int (*set_mute)(int);
 };
+
+void output_module_dump_modules(void);
+const struct output_module *output_module_get(const char *shortname);
+int output_module_add_goptions(GOptionContext *ctx);
+
 
 #endif
 

--- a/src/output_module.h
+++ b/src/output_module.h
@@ -26,12 +26,16 @@
 
 #include "output.h"
 
+#ifdef HAVE_GLIB
 typedef struct _GOptionContext GOptionContext;
+#endif
 
 struct output_module {
         const char *shortname;
         const char *description;
+#ifdef HAVE_GLIB
 	int (*add_goptions)(GOptionContext *ctx);
+#endif
 
 	// Commands.
 	int (*init)(void);
@@ -53,8 +57,9 @@ struct output_module {
 
 void output_module_dump_modules(void);
 const struct output_module *output_module_get(const char *shortname);
+#ifdef HAVE_GLIB
 int output_module_add_goptions(GOptionContext *ctx);
-
+#endif
 
 #endif
 

--- a/src/output_mpg123.c
+++ b/src/output_mpg123.c
@@ -1,0 +1,385 @@
+/* output_mpg123.c - Output module for mpg123
+ *
+ * Copyright (C) 2014-2019   Mar Chalain
+ *
+ * This file is part of GMediaRender.
+ *
+ * GMediaRender is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GMediaRender is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GMediaRender; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA 02110-1301, USA.
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdarg.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <dlfcn.h>
+
+#include <upnp/ithread.h>
+
+#include <mpg123.h>
+
+#include <tinyalsa/asoundlib.h>
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "output_module.h"
+#include "output_mpg123.h"
+#include "sound_module.h"
+
+#include "logging.h"
+#include "upnp_connmgr.h"
+
+#include "webclient.h"
+
+enum e_state
+{
+	STOPPED,
+	PLAYING,
+	PAUSING,
+	HALTED,
+};
+enum e_state g_state = STOPPED;
+
+typedef struct st_output_mpg123_uri output_mpg123_uri_t;
+struct st_output_mpg123_uri
+{
+	char *uri;
+	enum e_state state;
+	size_t position;
+	struct http_info info;
+	output_mpg123_uri_t *next;
+};
+
+
+static output_mpg123_uri_t *g_first_uri;
+static output_mpg123_uri_t *g_current_uri;
+static output_transition_cb_t g_callback;
+
+static mpg123_pars *g_mpg123_pars;
+static mpg123_handle *g_mpg123_handle = NULL;
+
+static pthread_mutex_t g_mutex_control;
+static pthread_cond_t g_cond_control;
+
+static const char *g_cmd_mime = "audio/mpeg";
+static const struct sound_module *g_sound_api;
+
+static int
+output_mpg123_init(void)
+{
+	int ret = -1;
+
+	if (g_cmd_mime)
+	{
+		const char *mime = g_cmd_mime;
+		const char *nextmime = mime;
+		for (;*mime; mime++)
+		{
+			if (*mime == ',')
+			{
+				*(char *)mime = '\0';
+				register_mime_type(nextmime);
+				nextmime = mime + 1;
+			}
+		}
+		register_mime_type(nextmime);
+	}
+	pthread_mutex_init(&g_mutex_control, NULL);
+	pthread_cond_init(&g_cond_control, NULL);
+
+	ret = mpg123_init();
+	g_mpg123_pars = mpg123_new_pars(&ret);
+	const char **decoderslist = mpg123_decoders();
+	g_mpg123_handle = mpg123_new(decoderslist[0], &ret);
+
+	if (!ret)
+	{
+		g_sound_api = sound_module_get();
+		if (g_sound_api == NULL)
+		{
+			ret = -1;
+		}
+	}
+	return ret;
+}
+
+static void
+output_mpg123_set_uri(const char *uri,
+				     output_update_meta_cb_t meta_cb)
+{
+	struct st_output_mpg123_uri *entry = malloc(sizeof(*entry));
+	memset(entry, 0 ,sizeof(*entry));
+	entry->uri = strdup(uri);
+	if (g_state == PLAYING && g_current_uri != NULL)
+	{
+		g_current_uri->next = entry;
+	}
+	else
+	{
+		entry->next = g_first_uri;
+		g_first_uri = entry;
+	}
+};
+
+static void
+output_mpg123_set_next_uri(const char *uri)
+{
+	struct st_output_mpg123_uri *entry = malloc(sizeof(*entry));
+	memset(entry, 0 ,sizeof(*entry));
+	entry->uri = strdup(uri);
+	if (g_first_uri == NULL)
+	{
+		g_first_uri = entry;
+	}
+	else
+	{
+		struct st_output_mpg123_uri *it = g_first_uri;
+		while (it->next != NULL) it = it->next;
+		it->next = entry;
+	}
+}
+
+static int
+output_mpg123_openstream(int fdin, int *channels, int *encoding, long *rate, long *buffsize)
+{
+	if(mpg123_open_fd(g_mpg123_handle, fdin) != MPG123_OK)
+	{
+		return -1;
+	}
+
+	if (mpg123_getformat(g_mpg123_handle, rate, channels, encoding) != MPG123_OK)
+	{
+		return -1;
+	}
+	mpg123_format_none(g_mpg123_handle);
+	mpg123_format(g_mpg123_handle, *rate, *channels, *encoding);
+
+	*buffsize = mpg123_outblock(g_mpg123_handle);
+	return 0;
+}
+
+static void*
+thread_play(void *arg)
+{
+	while (g_state != HALTED)
+	{
+		pthread_mutex_lock(&g_mutex_control);
+		while (g_state == STOPPED)
+		{
+			pthread_cond_wait(&g_cond_control, &g_mutex_control);
+		} 
+		pthread_mutex_unlock(&g_mutex_control);
+		if (g_current_uri == NULL || g_current_uri->uri == NULL)
+			continue;
+
+		int fdin = http_get(g_current_uri->uri, &g_current_uri->info);
+		if (fdin < 0)
+			break;
+
+		int  channels = 0, encoding = 0;
+		long rate = 0, buffsize = 0;
+		if (output_mpg123_openstream(fdin, &channels, &encoding, &rate, &buffsize))
+		{
+			break;
+		}
+		unsigned char *buffer;
+		buffer = malloc(buffsize);
+
+		g_sound_api->open(channels, encoding, rate);
+
+		int err = MPG123_OK;
+		do
+		{
+			pthread_mutex_lock(&g_mutex_control);
+			while (g_state == PAUSING)
+			{
+				pthread_cond_wait(&g_cond_control, &g_mutex_control);
+			}
+			/**
+			 * stop is requested from the controler
+			 **/
+			if (g_state == STOPPED)
+			{
+				g_current_uri->position = 0;
+				pthread_mutex_unlock(&g_mutex_control);
+				break;
+			}
+			pthread_mutex_unlock(&g_mutex_control);
+			size_t done = 0;
+			err = mpg123_read( g_mpg123_handle, buffer, buffsize, &done );
+			g_current_uri->position += done;
+			if (err == MPG123_OK)
+			{
+				err = (g_sound_api->write(buffer, buffsize) >= 0)? MPG123_OK : MPG123_ERR;
+			}
+		} while (err == MPG123_OK);
+		mpg123_close(g_mpg123_handle);
+		g_sound_api->close();
+
+		struct st_output_mpg123_uri *it = g_first_uri;
+		if (it == g_current_uri)
+		{
+			g_first_uri = g_first_uri->next;
+		}
+		else
+		{
+			while (it->next != g_current_uri) it = it->next;
+			it->next = it->next->next;
+		}
+
+		g_current_uri->position = g_current_uri->info.length;
+		/**
+		 * prepare the next stream
+		 **/
+		struct st_output_mpg123_uri *entry = g_current_uri->next;
+		free(g_current_uri->uri);
+		free(g_current_uri);
+		if (!entry)
+		{
+			(*g_callback)(PLAY_STOPPED);
+			g_current_uri = NULL;
+		}
+		else
+		{
+			g_current_uri = entry;
+			g_current_uri->position = 0;
+			(*g_callback)(PLAY_STARTED_NEXT_STREAM);
+		}
+	}
+	return NULL;
+}
+
+static int
+output_mpg123_loop()
+{
+	thread_play(NULL);
+	return 0;
+}
+
+static int
+output_mpg123_play(output_transition_cb_t callback)
+{
+	g_callback = callback;
+	g_state = PLAYING;
+	if (!g_current_uri)
+	{
+		struct st_output_mpg123_uri *entry = g_first_uri;
+		if (entry)
+		{
+			g_current_uri = entry;
+			g_current_uri->position = 0;
+
+//			pthread_t thread;
+//			pthread_create(&thread, NULL, thread_play, NULL);
+		}
+	}
+	pthread_cond_signal(&g_cond_control);
+	return 0;
+}
+
+static int
+output_mpg123_stop(void)
+{
+	g_state = STOPPED;
+	pthread_cond_signal(&g_cond_control);
+	return 0;
+}
+
+static int
+output_mpg123_pause(void)
+{
+	g_state = PAUSING;
+	pthread_cond_signal(&g_cond_control);
+	return 0;
+}
+
+static int
+output_mpg123_seek(int64_t position_nanos)
+{
+	return 0;
+}
+
+static int
+output_mpg123_get_position(int64_t *track_duration,
+					 int64_t *track_pos)
+{
+	if (g_current_uri == NULL)
+	{
+		*track_duration = 0;
+		*track_pos = 0;
+	}
+	else
+	{
+		*track_duration = g_current_uri->info.length;
+		*track_pos = g_current_uri->position;
+	}
+	return 0;
+}
+
+static int
+output_mpg123_getvolume(float *value)
+{
+	if (g_sound_api->get_volume)
+		return g_sound_api->get_volume(value);
+	return 0;
+}
+static int
+output_mpg123_setvolume(float value)
+{
+	if (g_sound_api->set_volume)
+		return g_sound_api->set_volume(value);
+	return 0;
+}
+static int
+output_mpg123_getmute(int *value)
+{
+	if (g_sound_api->get_mute)
+		return g_sound_api->get_mute(value);
+	return 0;
+}
+static int
+output_mpg123_setmute(int value)
+{
+	if (g_sound_api->set_mute)
+		return g_sound_api->set_mute(value);
+	return 0;
+}
+
+
+const struct output_module mpg123_output = {
+    .shortname = "mpg123",
+	.description = "daemon framework",
+	.init        = output_mpg123_init,
+	.loop        = output_mpg123_loop,
+	.set_uri     = output_mpg123_set_uri,
+	.set_next_uri= output_mpg123_set_next_uri,
+	.play        = output_mpg123_play,
+	.stop        = output_mpg123_stop,
+	.pause       = output_mpg123_pause,
+	.seek        = output_mpg123_seek,
+	.get_position = output_mpg123_get_position,
+	.get_volume  = output_mpg123_getvolume,
+	.set_volume  = output_mpg123_setvolume,
+	.get_mute  = output_mpg123_getmute,
+	.set_mute  = output_mpg123_setmute,
+};

--- a/src/output_mpg123.h
+++ b/src/output_mpg123.h
@@ -1,6 +1,6 @@
-/* output_gstreamer.h - Definitions for GStreamer output module
+/* output_mpg123.h - Definitions for GStreamer output module
  *
- * Copyright (C) 2005-2007   Ivo Clarysse
+ * Copyright (C) 2014-2019   Mar Chalain
  *
  * This file is part of GMediaRender.
  *
@@ -21,9 +21,9 @@
  *
  */
 
-#ifndef _OUTPUT_GSTREAMER_H
-#define _OUTPUT_GSTREAMER_H
+#ifndef _OUTPUT_MPG123_H
+#define _OUTPUT_MPG123_H
 
-extern const struct output_module gstreamer_output;
+extern const struct output_module mpg123_output;
 
-#endif /*  _OUTPUT_GSTREAMER_H */
+#endif /*  _OUTPUT_MPG123_H */

--- a/src/sound_alsa.c
+++ b/src/sound_alsa.c
@@ -1,0 +1,123 @@
+/* output_alsa.c - Sound module for alsa
+ *
+ * Copyright (C) 2014-2019   Mar Chalain
+ *
+ * This file is part of GMediaRender.
+ *
+ * GMediaRender is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GMediaRender is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GMediaRender; if not, write to the Free Software 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+ * MA 02110-1301, USA.
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdarg.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <errno.h>
+
+#include <pthread.h>
+#include <alsa/asoundlib.h>
+
+#include <mpg123.h>
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "logging.h"
+#include "sound_module.h"
+
+struct sound_alsa_global_s
+{
+        const char *cmd_card;
+        snd_pcm_t *pcm;
+        int samplesize;
+        struct fifo_s *fifo;
+};
+struct sound_alsa_global_s g = {
+        .cmd_card = "default",
+        .pcm = NULL,
+        .fifo = NULL
+};
+
+static int
+sound_alsa_open(int channels, int encoding, unsigned int rate)
+{
+	int ret;
+
+	ret = snd_pcm_open(&g.pcm, g.cmd_card, SND_PCM_STREAM_PLAYBACK, 0);
+
+	if (ret == -1 || g.pcm == NULL)
+		return -1;
+
+	snd_pcm_hw_params_t *hw_params;
+	ret = snd_pcm_hw_params_malloc(&hw_params);
+	ret = snd_pcm_hw_params_any(g.pcm, hw_params);
+	ret = snd_pcm_hw_params_set_access(g.pcm, hw_params, SND_PCM_ACCESS_RW_INTERLEAVED);
+	snd_pcm_format_t pcm_format;
+	switch (encoding)
+	{
+		case MPG123_ENC_SIGNED_32:
+			pcm_format = SND_PCM_FORMAT_S32_LE;
+			g.samplesize = 4 * 2;
+		break;
+		case MPG123_ENC_SIGNED_16:
+		default:
+			pcm_format = SND_PCM_FORMAT_S16_LE;
+			g.samplesize = 2 * 2;
+		break;
+	}
+	ret = snd_pcm_hw_params_set_format(g.pcm, hw_params, pcm_format);
+	ret = snd_pcm_hw_params_set_rate_near(g.pcm, hw_params, &rate, NULL);
+	ret = snd_pcm_hw_params_set_channels(g.pcm, hw_params, channels);
+
+	ret = snd_pcm_hw_params(g.pcm, hw_params);
+	ret = snd_pcm_prepare(g.pcm);
+
+	return 0;
+}
+
+static ssize_t
+sound_alsa_write(unsigned char *buffer, ssize_t size)
+{
+	snd_pcm_sframes_t ret;
+	ret = snd_pcm_writei(g.pcm, buffer, size / g.samplesize);
+	if (ret == -EPIPE)
+		ret = snd_pcm_recover(g.pcm, ret, 0);
+	return ret * g.samplesize;
+}
+
+static int
+sound_alsa_close(void)
+{
+	return snd_pcm_close(g.pcm);
+}
+
+struct sound_module const *g_sound_alsa = &(struct sound_module)
+{
+	.name = "alsa",
+	.open = sound_alsa_open,
+	.write = sound_alsa_write,
+	.close = sound_alsa_close,
+	.get_volume  = NULL,
+	.set_volume  = NULL,
+	.get_mute  = NULL,
+	.set_mute  = NULL,
+};

--- a/src/sound_module.c
+++ b/src/sound_module.c
@@ -1,15 +1,15 @@
-/* output_gstreamer.h - Definitions for GStreamer output module
+/* output_module.c - Sound module frontend
  *
- * Copyright (C) 2005-2007   Ivo Clarysse
+ * Copyright (C) 2014 - 2019 Marc Chalain
  *
  * This file is part of GMediaRender.
  *
- * GMediaRender is free software; you can redistribute it and/or modify
+ * uplaymusic is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
  *
- * GMediaRender is distributed in the hope that it will be useful,
+ * uplaymusic is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Library General Public License for more details.
@@ -19,11 +19,21 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
  * MA 02110-1301, USA.
  *
- */
+ */ 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
 
-#ifndef _OUTPUT_GSTREAMER_H
-#define _OUTPUT_GSTREAMER_H
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
 
-extern const struct output_module gstreamer_output;
+#include "sound_module.h"
 
-#endif /*  _OUTPUT_GSTREAMER_H */
+const struct sound_module *sound_module_get(void)
+{
+#ifdef HAVE_ALSA
+	return g_sound_alsa;
+#endif
+}

--- a/src/sound_module.h
+++ b/src/sound_module.h
@@ -1,6 +1,6 @@
-/* output_gstreamer.h - Definitions for GStreamer output module
+/* sound_module.h - Audio sink module
  *
- * Copyright (C) 2005-2007   Ivo Clarysse
+ * Copyright (C) 2014-2019   Marc Chalain
  *
  * This file is part of GMediaRender.
  *
@@ -21,9 +21,22 @@
  *
  */
 
-#ifndef _OUTPUT_GSTREAMER_H
-#define _OUTPUT_GSTREAMER_H
+#ifndef _SOUND_MODULE_H
+#define _SOUND_MODULE_H
+struct sound_module
+{
+	const char *name;
+	int (*open)(int channels, int encoding, unsigned int rate);
+	ssize_t (*write)(unsigned char *buffer, ssize_t size);
+	int (*close)(void);
+	int (*get_volume)(float *);
+	int (*set_volume)(float);
+	int (*get_mute)(int *);
+	int (*set_mute)(int);
+};
 
-extern const struct output_module gstreamer_output;
+const struct sound_module *sound_module_get(void);
 
-#endif /*  _OUTPUT_GSTREAMER_H */
+extern const struct sound_module *g_sound_alsa;
+
+#endif

--- a/src/upnp_device.c
+++ b/src/upnp_device.c
@@ -32,7 +32,6 @@
 #include <stdarg.h>
 #include <assert.h>
 #include <string.h>
-#include <glib.h>
 
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -403,7 +402,7 @@ static int event_handler(Upnp_EventType EventType, void *event, void *userdata)
 	return 0;
 }
 
-static gboolean initialize_device(struct upnp_device_descriptor *device_def,
+static int initialize_device(struct upnp_device_descriptor *device_def,
 				  struct upnp_device *result_device,
 				  const char *ip_address,
 				  unsigned short port)

--- a/src/upnp_transport.c
+++ b/src/upnp_transport.c
@@ -34,8 +34,6 @@
 #include <string.h>
 #include <assert.h>
 
-#include <glib.h>
-
 #include <upnp/upnp.h>
 #include <upnp/ithread.h>
 
@@ -743,38 +741,38 @@ static int get_transport_settings(struct action_event *event)
 }
 
 // Print UPnP formatted time into given buffer. time given in nanoseconds.
-static int divide_leave_remainder(gint64 *val, gint64 divisor) {
+static int divide_leave_remainder(int64_t *val, int64_t divisor) {
 	int result = *val / divisor;
 	*val %= divisor;
 	return result;
 }
-static void print_upnp_time(char *result, size_t size, gint64 t) {
-	const gint64 one_sec = 1000000000LL;  // units are in nanoseconds.
+static void print_upnp_time(char *result, size_t size, int64_t t) {
+	const int64_t one_sec = 1000000000LL;  // units are in nanoseconds.
 	const int hour = divide_leave_remainder(&t, 3600LL * one_sec);
 	const int minute = divide_leave_remainder(&t, 60LL * one_sec);
 	const int second = divide_leave_remainder(&t, one_sec);
 	snprintf(result, size, "%d:%02d:%02d", hour, minute, second);
 }
 
-static gint64 parse_upnp_time(const char *time_string) {
+static int64_t parse_upnp_time(const char *time_string) {
 	int hour = 0;
 	int minute = 0;
 	int second = 0;
 	sscanf(time_string, "%d:%02d:%02d", &hour, &minute, &second);
-	const gint64 seconds = (hour * 3600 + minute * 60 + second);
-	const gint64 one_sec_unit = 1000000000LL;
+	const int64_t seconds = (hour * 3600 + minute * 60 + second);
+	const int64_t one_sec_unit = 1000000000LL;
 	return one_sec_unit * seconds;
 }
 
 // We constantly update the track time to event about it to our clients.
 static void *thread_update_track_time(void *userdata) {
-	const gint64 one_sec_unit = 1000000000LL;
+	const int64_t one_sec_unit = 1000000000LL;
 	char tbuf[32];
-	gint64 last_duration = -1, last_position = -1;
+	int64_t last_duration = -1, last_position = -1;
 	for (;;) {
 		usleep(500000);  // 500ms
 		service_lock();
-		gint64 duration, position;
+		int64_t duration, position;
 		const int pos_result = output_get_position(&duration, &position);
 		if (pos_result == 0) {
 			if (duration != last_duration) {
@@ -971,7 +969,7 @@ static int seek(struct action_event *event)
 	if (strcmp(unit, "REL_TIME") == 0) {
 		// This is the only thing we support right now.
 		const char *target = upnp_get_string(event, "Target");
-		gint64 nanos = parse_upnp_time(target);
+		int64_t nanos = parse_upnp_time(target);
 		service_lock();
 		if (output_seek(nanos) == 0) {
 			// TODO(hzeller): Seeking might take some time,

--- a/src/webclient.c
+++ b/src/webclient.c
@@ -1,0 +1,229 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/ioctl.h>
+
+#include <errno.h>
+#include <sched.h>
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+
+#include "webclient.h"
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "logging.h"
+
+static int http_get_transaction(int fd, struct http_info *info)
+{
+	int ret = -1;
+	int len;
+
+	/**
+	 * generate the request
+	 **/
+	char *wbuff;
+	wbuff = malloc(1024 + 1);
+	len = 0;
+	const char *method = "GET";
+	const char *page = "/index.html";
+	if (info->method != NULL)
+		method = info->method;
+	if (info->uri != NULL)
+		page = info->uri;
+	sprintf(wbuff+len, "%s %s HTTP/1.0\r\n", method, page);
+	len += strlen(page) + 15;
+/*
+ * 	sprintf(wbuff+len, "User-Agent: mpg123/1.12.1\r\n");
+	len += 27;
+	sprintf(wbuff+len, "Host: 10.1.2.9:49152\r\n");
+	len += 22;
+	sprintf(wbuff+len, "Accept: audio/mpeg, audio/x-mpeg, audio/mp3, audio/x-mp3, audio/mpeg3, audio/x-mpeg3, audio/mpg, audio/x-mpg, audio/x-mpegaudio, audio/mpegurl, audio/mpeg-url, audio/x-mpegurl, audio/x-scpls, audio/scpls, application/pls\r\n");
+	len += 227;
+*/
+	sprintf(wbuff+len, "\r\n");
+	len += 2;
+	
+	/**
+	 * send the request
+	 **/
+	ret = write(fd, wbuff, len);
+	free(wbuff);
+
+	/**
+	 * look for bytes available on the connection
+	 **/
+	//int ret;
+	fd_set rfds;
+	int maxfd;
+
+	FD_ZERO(&rfds);
+	FD_SET(fd, &rfds);
+	maxfd = fd +1;
+
+	do
+	{
+		ret = select(maxfd, &rfds, NULL, NULL, NULL);
+	} while (ret <= 0 || !FD_ISSET(fd, &rfds));
+
+	/**
+	 * allocate buffer with enought space for the header
+	 **/
+	char rbuff[1024];
+	char *it = rbuff;
+	memset(rbuff, 0, sizeof(rbuff));
+	while (ret > 0)
+	{
+		char tbuff[1];
+		len = 1;
+		
+		ret = recv(fd, tbuff, len, 0);
+		*it = tbuff[0];
+		if (ret < 0)
+		{
+			//LOG_ERROR("read from socket error %d %s", ret, strerror(errno));
+			return -1;
+		}
+		if (strstr(rbuff, "\r\n\r\n"))
+		{
+			Log_info("webclient", "header:\n%s", rbuff);
+			break;
+		}
+		it += ret;
+		if (it == rbuff + sizeof(rbuff))
+		{
+			while (*it != '\n') it--;
+			int len = rbuff + sizeof(rbuff) - it;
+			memcpy(rbuff, it, len);
+			it = rbuff + len;
+		}
+	}
+	/**
+	 * parse the header
+	 **/
+	char *value;
+	if ((value = strstr(rbuff, "Content-Length: ")))
+	{
+		sscanf(value,"Content-Length: %u[^\r]", &info->length);
+	}
+	if ((value = strstr(rbuff, "Content-Type: ")))
+	{
+		sscanf(value,"Content-Type: %99[^\r]", info->mime);
+	}
+
+	return ret;
+}
+
+int
+http_get(char *uri, struct http_info *info)
+{
+	int fd = -1;
+	int port = 0;
+	char proto[10];
+	char ip[100];
+	char page[200];
+	int err = -1;
+
+	memset(proto, 0, 10);
+	memset(ip, 0, 100);
+	memset(page, 0, 100);
+	port = 80;
+
+	page[0]='/';
+	if (sscanf(uri, "%9[^:]://%99[^:]:%i/%198[^\n]", proto, ip, &port, page+1) == 4) { err = 0;}
+	else if (sscanf(uri, "%9[^:]://%99[^/]/%198[^\n]", proto, ip, page+1) == 3) { err = 0;}
+	else if (sscanf(uri, "%9[^:]://%99[^:]:%i[^\n]", proto, ip, &port) == 3) { err = 0;}
+	else if (sscanf(uri, "%9[^:]://%99[^\n]", proto, ip) == 2) { err = 0;}
+
+	if (!err)
+	{
+#ifndef IPV6
+		struct sockaddr_in server;
+
+		if((server.sin_addr.s_addr = inet_addr(ip)) == INADDR_NONE)
+		return -1;
+
+		server.sin_port = htons(port);
+		server.sin_family = AF_INET;
+
+		if((fd = socket(PF_INET, SOCK_STREAM, 6)) < 0)
+		{
+			return -1;
+		}
+		if(connect(fd, (struct sockaddr *)&server, sizeof(server)))
+			return -1;
+#else
+		struct addrinfo hints;
+
+		memset(&hints, 0, sizeof(struct addrinfo));
+		hints.ai_family = AF_UNSPEC;    /* Allow IPv4 or IPv6 */
+		hints.ai_socktype = SOCK_DGRAM; /* Datagram socket */
+		hints.ai_flags = 0;
+		hints.ai_protocol = 0;          /* Any protocol */
+		if (strncmp(proto,"http",4))
+		{
+			LOG_ERROR("bad protocol type %s", proto);
+			return -1;
+		}
+		struct addrinfo *result, *rp;
+		char aport[6];
+		sprintf(aport,"%u",port);
+
+		err = getaddrinfo(ip, aport, &hints, &result);
+		if (err)
+			return err;
+
+		for (rp = result; rp != NULL; rp = rp->ai_next)
+		{
+			int yes = 0;
+
+			fd = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+			if (fd == -1)
+				continue;
+			else if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes)) < 0)
+			{
+				close(fd);
+				fd = -errno;
+				continue;
+			}
+
+			if (connect(fd, rp->ai_addr, rp->ai_addrlen) != -1)
+				break;                  /* Success */
+
+			close(fd);
+		}
+		freeaddrinfo(result);
+		if (rp == NULL)
+			return -1;
+#endif
+
+		info->uri = uri;
+		http_get_transaction(fd, info);
+
+	}
+	return fd;
+}
+
+#ifdef HTTP_GET_MAIN
+int main(int argc, char **argv)
+{
+	if (argc > 1);
+	{
+		struct http_info info;
+		int fd;
+		fd = http_get(argv[1], &info);
+		printf("content length = %u\n",info.length);
+		printf("content type = %s\n",info.mime);
+		if (fd > 0)
+			close(fd);
+	}
+	return 0;
+}
+#endif

--- a/src/webclient.h
+++ b/src/webclient.h
@@ -1,0 +1,13 @@
+#ifndef __NETWORK_HTTP_GET_H__
+#define __NETWORK_HTTP_GET_H__
+struct http_info
+{
+	const char *method;
+	const char *uri;
+	unsigned int length;
+	char mime[100];
+};
+
+extern int http_get(char *uri, struct http_info *info);
+
+#endif

--- a/src/webserver.c
+++ b/src/webserver.c
@@ -267,7 +267,7 @@ static struct UpnpVirtualDirCallbacks virtual_dir_callbacks = {
 	webserver_close
 };
 
-gboolean webserver_register_callbacks(void) {
+int webserver_register_callbacks(void) {
   int rc = UpnpSetVirtualDirCallbacks(&virtual_dir_callbacks);
   if (UPNP_E_SUCCESS != rc) {
     Log_error("webserver", "UpnpSetVirtualDirCallbacks() Error: %s (%d)",
@@ -287,8 +287,8 @@ gboolean webserver_register_callbacks(void) {
 // Assuming that they will go on with this broken idea and eventually remove
 // the support for the VirtualDirCallbacks in new major versions, we use the
 // newer (may I emphasize: questionable) API to register the callbacks.
-gboolean webserver_register_callbacks(void) {
-  gboolean result =
+int webserver_register_callbacks(void) {
+  int result =
     (UpnpVirtualDir_set_GetInfoCallback(webserver_get_info) == UPNP_E_SUCCESS
      && UpnpVirtualDir_set_OpenCallback(webserver_open) == UPNP_E_SUCCESS
      && UpnpVirtualDir_set_ReadCallback(webserver_read) == UPNP_E_SUCCESS

--- a/src/webserver.h
+++ b/src/webserver.h
@@ -24,10 +24,8 @@
 #ifndef _WEBSERVER_H
 #define _WEBSERVER_H
 
-#include <glib.h>
-
 // Start the webserver with the registered files.
-gboolean webserver_register_callbacks(void);
+int webserver_register_callbacks(void);
 
 int webserver_register_buf(const char *path, const char *contents,
                            const char *content_type);


### PR DESCRIPTION
Hello, I use GMediaRenderer for my connected speaker. For that I use a Raspberry PI and a sound card. The system is built with Buildroot and I try to generate the smallest image as possible, and use less memory as possible to do other things at the same time.
I wrote this patch a long time ago and I distributed into a fork of your application. But now I think it is better to send it to you.
For that gstreamer and glib is to much in my mind then I wrote an output module that uses mpg123 and Alsa.
This is the reason of this pull request.
A future pull request will be to push glib dependence into a choice during the configuration of the build.
I hope that you will accept the both push requests.
Best regard,
Marc.