### PR TITLE
Eliminate memory waste in scan_mime_list

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -171,15 +171,18 @@ static gboolean process_cmdline(int argc, char **argv)
 	rc = output_add_options(ctx);
 	if (rc != 0) {
 		fprintf(stderr, "Failed to add output options\n");
+		g_option_context_free(ctx);
 		return FALSE;
 	}
 
 	if (!g_option_context_parse (ctx, &argc, &argv, &err)) {
 		fprintf(stderr, "Failed to initialize: %s\n", err->message);
 		g_error_free (err);
+		g_option_context_free(ctx);
 		return FALSE;
 	}
 
+	g_option_context_free(ctx);
 	return TRUE;
 }
 

--- a/src/output_gstreamer.c
+++ b/src/output_gstreamer.c
@@ -46,74 +46,74 @@ static double buffer_duration = 0.0; /* Buffer disbled by default, see #182 */
 
 static void scan_mime_list(void)
 {
-  GstRegistry* registry = NULL;
+	GstRegistry* registry = NULL;
 
 #if (GST_VERSION_MAJOR < 1)
-  registry = gst_registry_get_default();
+	registry = gst_registry_get_default();
 #else
-  registry = gst_registry_get();
+	registry = gst_registry_get();
 #endif
 
-  // Fetch a list of all element factories
-  GList* features =
-      gst_registry_get_feature_list(registry, GST_TYPE_ELEMENT_FACTORY);
+	// Fetch a list of all element factories
+	GList* features =
+		gst_registry_get_feature_list(registry, GST_TYPE_ELEMENT_FACTORY);
 
-  // Save a copy of the list root so we can properly free later
-  GList* root = features;
+	// Save a copy of the list root so we can properly free later
+	GList* root = features;
 
-  while (features != NULL) {
-    GstPluginFeature* feature = GST_PLUGIN_FEATURE(features->data);
+	while (features != NULL) {
+		GstPluginFeature* feature = GST_PLUGIN_FEATURE(features->data);
 
-    // Advance list
-    features = g_list_next(features);
+		// Advance list
+		features = g_list_next(features);
 
-    // Better be an element factory
-    assert(GST_IS_ELEMENT_FACTORY(feature));
+		// Better be an element factory
+		assert(GST_IS_ELEMENT_FACTORY(feature));
 
-    GstElementFactory* factory = GST_ELEMENT_FACTORY(feature);
+		GstElementFactory* factory = GST_ELEMENT_FACTORY(feature);
 
-    // Ignore elements without pads
-    if (gst_element_factory_get_num_pad_templates(factory) == 0) continue;
+		// Ignore elements without pads
+		if (gst_element_factory_get_num_pad_templates(factory) == 0) continue;
 
-    // Fetch a list of all pads
-    const GList* pads = gst_element_factory_get_static_pad_templates(factory);
+		// Fetch a list of all pads
+		const GList* pads = gst_element_factory_get_static_pad_templates(factory);
 
-    while (pads) {
-      GstStaticPadTemplate* padTemplate = (GstStaticPadTemplate*)pads->data;
+		while (pads) {
+			GstStaticPadTemplate* padTemplate = (GstStaticPadTemplate*)pads->data;
 
-      // Advance list
-      pads = g_list_next(pads);
+			// Advance list
+			pads = g_list_next(pads);
 
-      // Skip pads that aren't sinks
-      if (padTemplate->direction != GST_PAD_SINK) continue;
+			// Skip pads that aren't sinks
+			if (padTemplate->direction != GST_PAD_SINK) continue;
 
-      // This is literally all known pad presences so it should be OK!
-      assert(padTemplate->presence == GST_PAD_ALWAYS ||
-             padTemplate->presence == GST_PAD_SOMETIMES ||
-             padTemplate->presence == GST_PAD_REQUEST);
+			// This is literally all known pad presences so it should be OK!
+			assert(padTemplate->presence == GST_PAD_ALWAYS ||
+				   padTemplate->presence == GST_PAD_SOMETIMES ||
+				   padTemplate->presence == GST_PAD_REQUEST);
 
-      GstCaps* capabilities = gst_static_caps_get(&padTemplate->static_caps);
+			GstCaps* capabilities = gst_static_caps_get(&padTemplate->static_caps);
 
-      // Skip capabilities that they tell us nothing
-      if (capabilities == NULL || gst_caps_is_any(capabilities) ||
-          gst_caps_is_empty(capabilities))
-        {
-          gst_caps_unref(capabilities);
-          continue;
-        }
+			// Skip capabilities that they tell us nothing
+			if (capabilities == NULL || gst_caps_is_any(capabilities) ||
+				gst_caps_is_empty(capabilities))
+			{
+				gst_caps_unref(capabilities);
+				continue;
+			}
 
-      for (guint i = 0; i < gst_caps_get_size(capabilities); i++) {
-        GstStructure* structure = gst_caps_get_structure(capabilities, i);
+			for (guint i = 0; i < gst_caps_get_size(capabilities); i++) {
+				GstStructure* structure = gst_caps_get_structure(capabilities, i);
 
-        register_mime_type(gst_structure_get_name(structure));
-      }
+				register_mime_type(gst_structure_get_name(structure));
+			}
 
-      gst_caps_unref(capabilities);
-    }
-  }
+			gst_caps_unref(capabilities);
+		}
+	}
 
 	// Free any allocated memory
-  gst_plugin_feature_list_free(root);
+	gst_plugin_feature_list_free(root);
 
 	// There seem to be all kinds of mime types out there that start with
 	// "audio/" but are not explicitly supported by gstreamer. Let's just

--- a/src/output_gstreamer.c
+++ b/src/output_gstreamer.c
@@ -44,111 +44,72 @@
 
 static double buffer_duration = 0.0; /* Buffer disbled by default, see #182 */
 
-static void scan_caps(const GstCaps * caps)
+static void scan_mime_list(void)
 {
-	guint i;
+  GstRegistry* registry = NULL;
 
-	g_return_if_fail(caps != NULL);
+#if (GST_VERSION_MAJOR < 1)
+  registry = gst_registry_get_default();
+#else
+  registry = gst_registry_get();
+#endif
 
-	if (gst_caps_is_any(caps)) {
-		return;
-	}
-	if (gst_caps_is_empty(caps)) {
-		return;
-	}
+  // Fetch a list of all element factories
+  const GList* features =
+      gst_registry_get_feature_list(registry, GST_TYPE_ELEMENT_FACTORY);
 
-	for (i = 0; i < gst_caps_get_size(caps); i++) {
-		GstStructure *structure = gst_caps_get_structure(caps, i);
-		const char *mime_type = gst_structure_get_name(structure);
-		register_mime_type(mime_type);
-	}
+  while (features != NULL) {
+    GstPluginFeature* feature = GST_PLUGIN_FEATURE(features->data);
+
+    // Advance list
+    features = g_list_next(features);
+
+    // Better be an element factory
+    assert(GST_IS_ELEMENT_FACTORY(feature));
+
+    GstElementFactory* factory = GST_ELEMENT_FACTORY(feature);
+
+    // Ignore elements without pads
+    if (gst_element_factory_get_num_pad_templates(factory) == 0) continue;
+
+    // Fetch a list of all pads
+    const GList* pads = gst_element_factory_get_static_pad_templates(factory);
+
+    while (pads) {
+      GstStaticPadTemplate* padTemplate = (GstStaticPadTemplate*)pads->data;
+
+      // Advance list
+      pads = g_list_next(pads);
+
+      // Skip pads that aren't sinks
+      if (padTemplate->direction != GST_PAD_SINK) continue;
+
+      // This is literally all known pad presences so it should be OK!
+      assert(padTemplate->presence == GST_PAD_ALWAYS ||
+             padTemplate->presence == GST_PAD_SOMETIMES ||
+             padTemplate->presence == GST_PAD_REQUEST);
+
+      GstCaps* capabilities = gst_static_caps_get(&padTemplate->static_caps);
+
+      // Skip capabilities that they tell us nothing
+      if (capabilities == NULL || gst_caps_is_any(capabilities) ||
+          gst_caps_is_empty(capabilities))
+        continue;
+
+      for (guint i = 0; i < gst_caps_get_size(capabilities); i++) {
+        GstStructure* structure = gst_caps_get_structure(capabilities, i);
+
+        register_mime_type(gst_structure_get_name(structure));
+      }
+    }
+  }
+
 	// There seem to be all kinds of mime types out there that start with
 	// "audio/" but are not explicitly supported by gstreamer. Let's just
 	// tell the controller that we can handle everything "audio/*" and hope
 	// for the best.
 	register_mime_type("audio/*");
 }
-
-static void scan_pad_templates_info(GstElement *element,
-				    GstElementFactory *factory)
-{
-	(void)factory;
-
-	const GList *pads;
-	GstPadTemplate *padtemplate;
-	GstElementClass *element_class;
-
-	element_class = GST_ELEMENT_GET_CLASS(element);
-
-	if (!element_class->numpadtemplates) {
-		return;
-	}
-
-	pads = element_class->padtemplates;
-	while (pads) {
-		padtemplate = (GstPadTemplate *) (pads->data);
-		//GstPad *pad = (GstPad *) (pads->data);
-		pads = g_list_next(pads);
-
-		if ((padtemplate->direction == GST_PAD_SINK) &&
-		    ((padtemplate->presence == GST_PAD_ALWAYS) ||
-		     (padtemplate->presence == GST_PAD_SOMETIMES) ||
-		     (padtemplate->presence == GST_PAD_REQUEST)) &&
-		    (padtemplate->caps)) {
-			scan_caps(padtemplate->caps);
-		}
-	}
-
-}
-
-
-static void scan_mime_list(void)
-{
-	GstRegistry *registry = NULL;
-	GList *plugins = NULL;
-
-#if (GST_VERSION_MAJOR < 1)
-	registry = gst_registry_get_default();
-	plugins = gst_default_registry_get_plugin_list();
-#else
-	registry = gst_registry_get();
-	plugins = gst_registry_get_plugin_list(registry);
-#endif
-
-	while (plugins) {
-		GList *features;
-		GstPlugin *plugin;
-
-		plugin = (GstPlugin *) (plugins->data);
-		plugins = g_list_next(plugins);
-
-		features =
-			gst_registry_get_feature_list_by_plugin(registry,
-							    gst_plugin_get_name
-							    (plugin));
-
-		while (features) {
-			GstPluginFeature *feature;
-
-			feature = GST_PLUGIN_FEATURE(features->data);
-
-			if (GST_IS_ELEMENT_FACTORY(feature)) {
-				GstElementFactory *factory;
-				GstElement *element;
-				factory = GST_ELEMENT_FACTORY(feature);
-				element =
-				    gst_element_factory_create(factory, NULL);
-				if (element) {
-					scan_pad_templates_info(element,
-								factory);
-				}
-			}
-
-			features = g_list_next(features);
-		}
-	}
-}
-
 
 static GstElement *player_ = NULL;
 static char *gsuri_ = NULL;         // locally strdup()ed


### PR DESCRIPTION
Also gives a nice boost to start-up time. Addresses issue #199. Pulled from PR #194 