### PR TITLE
Implement Track Metadata via C++ class (XMLDoc)

### DIFF
--- a/src/output_gstreamer.cc
+++ b/src/output_gstreamer.cc
@@ -304,6 +304,7 @@ void GstreamerOutput::SetUri(const std::string& uri) {
   Log_info(TAG, "Set uri to '%s'", uri.c_str());
 
   uri_ = uri;
+  metadata_.Clear();
 }
 
 /**
@@ -536,6 +537,71 @@ void GstreamerOutput::NextStream(void) {
 }
 
 /**
+  @brief  Update the metadata for a given tag_name from the tag_list
+
+  @param  tag_list GstTagList from the GST_MESSAGE_TAG
+  @param  tag_name Tag name to update
+  @retval void
+*/
+void GstreamerOutput::UpdateMetadata(const GstTagList* tag_list,
+                                     const gchar* tag_name) {
+  // Validate input paramters
+  assert(tag_list && tag_name);
+
+  // Do nothing is tag is not supported
+  if (metadata_.TagSupported(tag_name) == false) return;
+
+  std::string new_tag;
+  GType type = gst_tag_get_type(tag_name);  // Can't switch. Non-constexpr types
+  if (type == G_TYPE_STRING) {
+    // Attempt to fetch the tag
+    gchar* value = NULL;
+    if (gst_tag_list_get_string(tag_list, tag_name, &value) == false) return;
+
+    // Copy into a string
+    new_tag = std::string(value);
+
+    // Free the tag buffer
+    g_free(value);
+  } else if (type == GST_TYPE_DATE_TIME) {
+    // Attempt to fetch the tag
+    GstDateTime* value = NULL;
+    if (gst_tag_list_get_date_time(tag_list, tag_name, &value) == false) return;
+
+    // Need at least a year
+    if (gst_date_time_has_year(value) == false) return;
+
+    uint32_t year = gst_date_time_get_year(value);
+    // Insert bogus month and day if none present
+    uint8_t month =
+        gst_date_time_has_month(value) ? gst_date_time_get_month(value) : 1;
+    uint8_t day =
+        gst_date_time_has_day(value) ? gst_date_time_get_day(value) : 1;
+
+    // Free the buffer
+    gst_date_time_unref(value);
+
+    // Mimic basic ISO8601 format
+    char buffer[12] = {0};
+    snprintf(buffer, sizeof(buffer), "%d-%02d-%02d", year, month, day);
+
+    new_tag = std::string(buffer);
+  } else if (type == G_TYPE_UINT) {
+    guint value = 0;
+    if (gst_tag_list_get_uint(tag_list, tag_name, &value) == false) return;
+
+    new_tag = std::to_string(value);
+  } else {
+    Log_warn(TAG, "Tag: '%s' is an unknown type '%s'", tag_name,
+             g_type_name(type));
+  }
+
+  metadata_[tag_name] = new_tag;
+
+  // Log_info(TAG, "Got tag: '%s' value: '%s'", tag_name, ((std::string) tag).c_str());
+}
+
+/**
   @brief  Handle message from the Gstreamer bus
 
   @param  message GstMessage to process
@@ -604,11 +670,15 @@ bool GstreamerOutput::BusCallback(GstMessage* message) {
       GstTagList* tag_list = NULL;
       gst_message_parse_tag(message, &tag_list);
 
-      if (metadata_.UpdateFromTags(tag_list)) {
-        NotifyMetadataChange(metadata_);
-      }
+      auto addTag = [](const GstTagList* list, const gchar* tag_name,
+                       gpointer user_data) {
+        ((GstreamerOutput*)user_data)->UpdateMetadata(list, tag_name);
+      };
 
+      gst_tag_list_foreach(tag_list, addTag, this);
       gst_tag_list_free(tag_list);
+
+      if (metadata_.Modified()) NotifyMetadataChange(metadata_);
 
       break;
     }

--- a/src/output_gstreamer.h
+++ b/src/output_gstreamer.h
@@ -83,6 +83,7 @@ class GstreamerOutput : public OutputModule,
  private:
   GstState GetPlayerState(void);
   void NextStream(void);
+  void UpdateMetadata(const GstTagList* list, const gchar* tag_name);
   bool BusCallback(GstMessage* message);
 
   GstElement* player_ = nullptr;

--- a/src/track-meta-data.cc
+++ b/src/track-meta-data.cc
@@ -70,25 +70,21 @@ void TrackMetadata::CreateXmlRoot(XMLDoc& xml_document) const {
 std::string TrackMetadata::ToXml(const std::string& xml) const {
   // Parse existing document
   auto xml_document = XMLDoc::Parse(xml);
-
-  XMLElement root;
+  
   XMLElement item;
-
   // Attempt to find root and item element from original XML
   if (xml_document != nullptr) {
-    root = xml_document->findElement("DIDL-Lite");
-    item = root.findElement("item");
+    item = xml_document->findElement("DIDL-Lite").findElement("item");
   }
 
   // Existing format sucks, just make our own
-  if (!root.exists() || !item.exists()) {
+  if (!item.exists()) {
     xml_document.reset(new XMLDoc());
 
     CreateXmlRoot(*xml_document);
 
     // Update locals with new document objects
-    root = xml_document->findElement("DIDL-Lite");
-    item = root.findElement("item");
+    item = xml_document->findElement("DIDL-Lite").findElement("item");
   }
 
   bool modified = false;

--- a/src/track-meta-data.cc
+++ b/src/track-meta-data.cc
@@ -75,15 +75,14 @@ std::string TrackMetadata::ToXml(const std::string& xml) const {
   XMLElement item;
 
   // Attempt to find root and item element from original XML
-  if (xml_document != nullptr)
-  {
+  if (xml_document != nullptr) {
     root = xml_document->findElement("DIDL-Lite");
     item = root.findElement("item");
   }
 
   // Existing format sucks, just make our own
   if (!root.exists() || !item.exists()) {
-    xml_document = std::unique_ptr<XMLDoc>(new XMLDoc()); // This is awkward
+    xml_document.reset(new XMLDoc());
 
     CreateXmlRoot(*xml_document);
 

--- a/src/track-meta-data.h
+++ b/src/track-meta-data.h
@@ -205,4 +205,4 @@ class TrackMetadata {
   };
 };
 
-#endif  // _SONG_META_DATA_H
+#endif  // _TRACK_META_DATA_H


### PR DESCRIPTION
Implement Track Metadata via C++ class
- Support referencing by enum and string
- Direct access to const std::string values
- DIDL-Lite XML generated via XMLDoc
- Added support for track number and date tags

Rebased original PR #204 utilizing the XMLDoc class instead of a 3rd party XML lib