### PR TITLE
Remove dependencies on glib from core application

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -10,6 +10,7 @@ gmediarender_SOURCES = main.c git-version.h \
 	webserver.c webserver.h \
 	output.c output.h \
 	logging.h logging.c \
+	gmrender_list.c gmrender_list.h \
 	xmldoc.c xmldoc.h \
 	xmlescape.c xmlescape.h
 

--- a/src/gmrender_list.c
+++ b/src/gmrender_list.c
@@ -1,0 +1,109 @@
+/* gmrender_list.c - GList emulator
+ *
+ * Copyright (C) 2020   Marc Chalain
+ *
+ * Adapted to gstreamer-0.10 2006 David Siorpaes
+ * Adapted to output to snapcast 2017 Daniel Jäcksch
+ *
+ * This file is part of GMediaRender.
+ *
+ * GMediaRender is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GMediaRender is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GMediaRender; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+
+#include "gmrender_list.h"
+#include "logging.h"
+
+GmSList *gm_slist_prepend(GmSList *list, void *data)
+{
+	GmSList *new = calloc(1, sizeof(*new));
+	new->data = data;
+	new->next = list;
+	return new;
+}
+
+GmSList *gm_slist_append(GmSList *list, void *data)
+{
+	GmSList *new = calloc(1, sizeof(*new));
+	new->data = data;
+	if (list == NULL)
+		return new;
+
+	GmSList *it = list;
+	while (it->next != NULL) it = it->next;
+	it->next = new;
+	return list;
+}
+
+GmSList *gm_slist_insert_sorted(GmSList *list, void *data, GmCompareFunc cmp)
+{
+	GmSList *it = list;
+	GmSList *prev;
+	if (list == NULL) {
+		list = gm_slist_append(list, data);
+		return list;
+	}
+	prev = NULL;
+	while (it != NULL && cmp(data,it->data) > 0) {
+		prev = it;
+		it = it->next;
+	}
+	if (it != NULL && prev == NULL)
+		list = gm_slist_prepend(it, data);
+	else if (it != NULL)
+		prev->next = gm_slist_prepend(it, data);
+	else
+		list = gm_slist_append(list, data);
+	return list;
+}
+
+GmSList *gm_slist_find_custom(GmSList *list, const void *data, GmCompareFunc cmp)
+{
+	GmSList *it = list;
+
+	while (it != NULL && cmp(data,it->data) != 0) it = it->next;
+	if (it != NULL)
+		return it;
+	return NULL;
+}
+
+GmSList *gm_slist_delete_link(GmSList *list, void *data)
+{
+	if (list == NULL)
+		return list;
+	GmSList *it = list;
+	while (it->next != NULL && it->next->data != data) it = it->next;
+	if (it->next != NULL) {
+		GmSList *next = it->next;
+		it->next = it->next->next;
+		free(next);
+	}
+	else if (list->data == data) {
+		free(list);
+		list = NULL;
+	}
+
+	return list;
+}

--- a/src/gmrender_list.h
+++ b/src/gmrender_list.h
@@ -1,0 +1,57 @@
+/* gmrender_list.h - GList emulator
+ *
+ * Copyright (C) 2005-2007   Ivo Clarysse
+ *
+ * Adapted to gstreamer-0.10 2006 David Siorpaes
+ * Adapted to output to snapcast 2017 Daniel Jäcksch
+ *
+ * This file is part of GMediaRender.
+ *
+ * GMediaRender is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GMediaRender is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GMediaRender; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ *
+ */
+
+#ifndef _GMLIST_H
+#define _GMLIST_H
+
+typedef struct GmSList_s GmSList;
+struct GmSList_s {
+	void *data;
+	GmSList *next;
+};
+
+typedef int (*GmCompareFunc)(const void *, const void *);
+
+GmSList *gm_slist_prepend(GmSList *list, void *data);
+GmSList *gm_slist_append(GmSList *list, void *data);
+GmSList *gm_slist_insert_sorted(GmSList *list, void *data, GmCompareFunc cmp);
+GmSList *gm_slist_find_custom(GmSList *list, const void *data, GmCompareFunc cmp);
+GmSList *gm_slist_delete_link(GmSList *list, void *data);
+#define gm_slist_next(entry) (entry->next)
+#define gm_slist_free_full(list, free) do { \
+	if (list == NULL) break; \
+	GmSList *next = list->next; \
+	free(list->data); \
+	free(list); \
+	list = next; \
+} while(list != NULL)
+#define gm_slist_foreach(list, func, udata) do { \
+	if (list == NULL) break; \
+	func(list->data, udata); \
+	list = list->next; \
+} while(list != NULL)
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -30,7 +30,6 @@
 #endif
 
 #include <assert.h>
-#include <glib.h>
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -219,10 +218,6 @@ int main(int argc, char **argv)
 {
 	int rc;
 	struct upnp_device_descriptor *upnp_renderer;
-
-#if !GLIB_CHECK_VERSION(2,32,0)
-	g_thread_init (NULL);  // Was necessary < glib 2.32, deprecated since.
-#endif
 
 	if (!process_cmdline(&argc, &argv)) {
 		return EXIT_FAILURE;

--- a/src/main.c
+++ b/src/main.c
@@ -48,9 +48,6 @@
 
 // For version strings of upnp and gstreamer
 #include <upnpconfig.h>
-#ifdef HAVE_GST
-#  include <gst/gst.h>
-#endif
 
 #include "git-version.h"
 #include "logging.h"
@@ -112,18 +109,8 @@ static struct option option_entries[] = {
 
 // Fill buffer with version information. Returns pointer to beginning of string.
 static const char *GetVersionInfo(char *buffer, size_t len) {
-#ifdef HAVE_GST
-	snprintf(buffer, len, "gmediarender %s "
-		 "(libupnp-%s; glib-%d.%d.%d; gstreamer-%d.%d.%d)",
-		 GM_COMPILE_VERSION, UPNP_VERSION_STRING,
-		 GLIB_MAJOR_VERSION, GLIB_MINOR_VERSION, GLIB_MICRO_VERSION,
-		 GST_VERSION_MAJOR, GST_VERSION_MINOR, GST_VERSION_MICRO);
-#else
-	snprintf(buffer, len, "gmediarender %s "
-		 "(libupnp-%s; glib-%d.%d.%d; without gstreamer.)",
-		 GM_COMPILE_VERSION, UPNP_VERSION_STRING,
-		 GLIB_MAJOR_VERSION, GLIB_MINOR_VERSION, GLIB_MICRO_VERSION);
-#endif
+	snprintf(buffer, len, "gmediarender %s (libupnp-%s)",
+		 GM_COMPILE_VERSION, UPNP_VERSION_STRING);
 	return buffer;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -61,32 +61,32 @@
 #include "upnp_transport.h"
 #include "upnp_connmgr.h"
 
-static gboolean show_version = FALSE;
-static gboolean show_devicedesc = FALSE;
-static gboolean show_connmgr_scpd = FALSE;
-static gboolean show_control_scpd = FALSE;
-static gboolean show_transport_scpd = FALSE;
-static gboolean show_outputs = FALSE;
-static gboolean daemon_mode = FALSE;
+static int show_version = FALSE;
+static int show_devicedesc = FALSE;
+static int show_connmgr_scpd = FALSE;
+static int show_control_scpd = FALSE;
+static int show_transport_scpd = FALSE;
+static int show_outputs = FALSE;
+static int daemon_mode = FALSE;
 
 // IP-address seems strange in libupnp: they actually don't bind to
 // that address, but to INADDR_ANY (miniserver.c in upnp library).
 // Apparently they just use this for the advertisement ? Anyway, 0.0.0.0 would
 // not work.
-static const gchar *ip_address = NULL;
+static const char *ip_address = NULL;
 static int listen_port = 49494;
 
 #ifdef GMRENDER_UUID
 // Compile-time uuid.
-static const gchar *uuid = GMRENDER_UUID;
+static const char *uuid = GMRENDER_UUID;
 #else
-static const gchar *uuid = "GMediaRender-1_0-000-000-002";
+static const char *uuid = "GMediaRender-1_0-000-000-002";
 #endif
-static const gchar *friendly_name = PACKAGE_NAME;
-static const gchar *output = NULL;
-static const gchar *pid_file = NULL;
-static const gchar *log_file = NULL;
-static const gchar *mime_filter = NULL;
+static const char *friendly_name = PACKAGE_NAME;
+static const char *output = NULL;
+static const char *pid_file = NULL;
+static const char *log_file = NULL;
+static const char *mime_filter = NULL;
 
 /* Generic GMediaRender options */
 static GOptionEntry option_entries[] = {
@@ -159,7 +159,7 @@ static void do_show_version(void)
 	       PACKAGE_STRING, version);
 }
 
-static gboolean process_cmdline(int argc, char **argv)
+static int process_cmdline(int argc, char **argv)
 {
 	GOptionContext *ctx;
 	GError *err = NULL;
@@ -172,18 +172,18 @@ static gboolean process_cmdline(int argc, char **argv)
 	if (rc != 0) {
 		fprintf(stderr, "Failed to add output options\n");
 		g_option_context_free(ctx);
-		return FALSE;
+		return 0;
 	}
 
 	if (!g_option_context_parse (ctx, &argc, &argv, &err)) {
 		fprintf(stderr, "Failed to initialize: %s\n", err->message);
 		g_error_free (err);
 		g_option_context_free(ctx);
-		return FALSE;
+		return 0;
 	}
 
 	g_option_context_free(ctx);
-	return TRUE;
+	return 1;
 }
 
 static void log_variable_change(void *userdata, int var_num,

--- a/src/main.c
+++ b/src/main.c
@@ -159,23 +159,15 @@ static void do_show_version(void)
 	       PACKAGE_STRING, version);
 }
 
-static int process_cmdline(int argc, char **argv)
+static int process_cmdline(int *argc, char **argv[])
 {
 	GOptionContext *ctx;
 	GError *err = NULL;
-	int rc;
 
 	ctx = g_option_context_new("- GMediaRender");
 	g_option_context_add_main_entries(ctx, option_entries, NULL);
 
-	rc = output_add_options(ctx);
-	if (rc != 0) {
-		fprintf(stderr, "Failed to add output options\n");
-		g_option_context_free(ctx);
-		return 0;
-	}
-
-	if (!g_option_context_parse (ctx, &argc, &argv, &err)) {
+	if (!g_option_context_parse (ctx, argc, argv, &err)) {
 		fprintf(stderr, "Failed to initialize: %s\n", err->message);
 		g_error_free (err);
 		g_option_context_free(ctx);
@@ -229,7 +221,7 @@ int main(int argc, char **argv)
 	g_thread_init (NULL);  // Was necessary < glib 2.32, deprecated since.
 #endif
 
-	if (!process_cmdline(argc, argv)) {
+	if (!process_cmdline(&argc, &argv)) {
 		return EXIT_FAILURE;
 	}
 
@@ -283,6 +275,7 @@ int main(int argc, char **argv)
 		return EXIT_FAILURE;
 	}
 
+	output_add_options(&argc, &argv);
 	rc = output_init(output);
 	if (rc != 0) {
 		Log_error("main",

--- a/src/output.c
+++ b/src/output.c
@@ -130,14 +130,21 @@ int output_loop()
         return 0;
 }
 
-int output_add_options(GOptionContext *ctx)
+int output_add_options(int *argc, char **argv[])
 {
   	int count, i;
+	if (*argc > 1 && !strcmp((*argv)[1], "--")) {
+		int i;
+		for (i = 1; i < *argc; i++) {
+			(*argv)[i] = (*argv)[i + 1];
+		}
+		*argc = (*argc) - 1;
+	}
 
 	count = sizeof(modules) / sizeof(struct output_module *);
 	for (i = 0; i < count; ++i) {
 		if (modules[i]->add_options) {
-			int result = modules[i]->add_options(ctx);
+			int result = modules[i]->add_options(argc, argv);
 			if (result != 0) {
 				return result;
 			}

--- a/src/output.c
+++ b/src/output.c
@@ -114,25 +114,12 @@ int output_init(const char *shortname)
 	return 0;
 }
 
-static GMainLoop *main_loop_ = NULL;
-static void exit_loop_sighandler(int sig) {
-	if (main_loop_) {
-		// TODO(hzeller): revisit - this is not safe to do.
-		g_main_loop_quit(main_loop_);
-	}
-}
-
-int output_loop()
+int output_loop(void)
 {
-        /* Create a main loop that runs the default GLib main context */
-        main_loop_ = g_main_loop_new(NULL, FALSE);
-
-	signal(SIGINT, &exit_loop_sighandler);
-	signal(SIGTERM, &exit_loop_sighandler);
-
-        g_main_loop_run(main_loop_);
-
-        return 0;
+	if (output_module && output_module->loop) {
+		return output_module->loop();
+	}
+	return -1;
 }
 
 int output_add_options(int *argc, char **argv[])

--- a/src/output.c
+++ b/src/output.c
@@ -33,8 +33,6 @@
 #include <stdlib.h>
 #include <signal.h>
 
-#include <glib.h>
-
 #include "logging.h"
 #include "output_module.h"
 #ifdef HAVE_GST
@@ -178,14 +176,14 @@ int output_stop(void) {
 	return -1;
 }
 
-int output_seek(gint64 position_nanos) {
+int output_seek(int64_t position_nanos) {
 	if (output_module && output_module->seek) {
 		return output_module->seek(position_nanos);
 	}
 	return -1;
 }
 
-int output_get_position(gint64 *track_dur, gint64 *track_pos) {
+int output_get_position(int64_t *track_dur, int64_t *track_pos) {
 	if (output_module && output_module->get_position) {
 		return output_module->get_position(track_dur, track_pos);
 	}

--- a/src/output.c
+++ b/src/output.c
@@ -68,6 +68,11 @@ void output_dump_modules(void)
 			       modules[i]->shortname,
 			       modules[i]->description,
 			       (i==0) ? " (default)" : "");
+			if (modules[i]->version != NULL)
+			{
+				char buffer[128];
+				printf("\tversion: %s\n", modules[i]->version(buffer, sizeof(buffer)));
+			}
 		}
 	}
 }

--- a/src/output.h
+++ b/src/output.h
@@ -40,7 +40,7 @@ typedef void (*output_transition_cb_t)(enum PlayFeedback);
 typedef void (*output_update_meta_cb_t)(const struct SongMetaData *);
 
 int output_init(const char *shortname);
-int output_add_options(GOptionContext *ctx);
+int output_add_options(int *argc, char **argv[]);
 void output_dump_modules(void);
 
 int output_loop(void);

--- a/src/output.h
+++ b/src/output.h
@@ -24,7 +24,6 @@
 #ifndef _OUTPUT_H
 #define _OUTPUT_H
 
-#include <glib.h>
 #include "song-meta-data.h"
 
 // Feedback for the controlling part what is happening with the
@@ -51,8 +50,8 @@ void output_set_next_uri(const char *uri);
 int output_play(output_transition_cb_t done_callback);
 int output_stop(void);
 int output_pause(void);
-int output_get_position(gint64 *track_dur_nanos, gint64 *track_pos_nanos);
-int output_seek(gint64 position_nanos);
+int output_get_position(int64_t *track_dur_nanos, int64_t *track_pos_nanos);
+int output_seek(int64_t position_nanos);
 
 int output_get_volume(float *v);
 int output_set_volume(float v);

--- a/src/output_gstreamer.c
+++ b/src/output_gstreamer.c
@@ -194,7 +194,7 @@ static int output_gstreamer_pause(void) {
 	}
 }
 
-static int output_gstreamer_seek(gint64 position_nanos) {
+static int output_gstreamer_seek(int64_t position_nanos) {
 	if (gst_element_seek(player_, 1.0, GST_FORMAT_TIME,
 			     GST_SEEK_FLAG_FLUSH,
 			     GST_SEEK_TYPE_SET, position_nanos,
@@ -423,8 +423,8 @@ static int output_gstreamer_add_options(int *argc, char **argv[])
 	return 0;
 }
 
-static int output_gstreamer_get_position(gint64 *track_duration,
-					 gint64 *track_pos) {
+static int output_gstreamer_get_position(int64_t *track_duration,
+					 int64_t *track_pos) {
 	*track_duration = last_known_time_.duration;
 	*track_pos = last_known_time_.position;
 

--- a/src/output_gstreamer.c
+++ b/src/output_gstreamer.c
@@ -401,17 +401,25 @@ static GOptionEntry option_entries[] = {
 };
 
 
-static int output_gstreamer_add_options(GOptionContext *ctx)
+static int output_gstreamer_add_options(int *argc, char **argv[])
 {
-	GOptionGroup *option_group;
-	option_group = g_option_group_new("gstout", "GStreamer Output Options",
-	                                  "Show GStreamer Output Options",
-	                                  NULL, NULL);
-	g_option_group_add_entries(option_group, option_entries);
+	GOptionContext *ctx;
+	GError *err = NULL;
 
-	g_option_context_add_group (ctx, option_group);
+	ctx = g_option_context_new("- GStreamer Output Options");
+	g_option_context_add_main_entries(ctx, option_entries, NULL);
 
 	g_option_context_add_group (ctx, gst_init_get_option_group ());
+
+	if (!g_option_context_parse (ctx, argc, argv, &err)) {
+		fprintf(stderr, "Failed to initialize: %s\n", err->message);
+		g_error_free (err);
+		g_option_context_free(ctx);
+		return 0;
+	}
+
+	g_option_context_free(ctx);
+
 	return 0;
 }
 

--- a/src/output_gstreamer.c
+++ b/src/output_gstreamer.c
@@ -585,10 +585,20 @@ static int output_gstreamer_init(void)
 	return 0;
 }
 
+static const char *output_gstreamer_version(char *buffer, size_t len)
+{
+	snprintf(buffer, len, "%s (glib-%d.%d.%d; gstreamer-%d.%d.%d)",
+		 PACKAGE_VERSION,
+		 GLIB_MAJOR_VERSION, GLIB_MINOR_VERSION, GLIB_MICRO_VERSION,
+		 GST_VERSION_MAJOR, GST_VERSION_MINOR, GST_VERSION_MICRO);
+	return buffer;
+}
+
 struct output_module gstreamer_output = {
         .shortname = "gst",
 	.description = "GStreamer multimedia framework",
 	.add_options = output_gstreamer_add_options,
+	.version = output_gstreamer_version,
 
 	.init        = output_gstreamer_init,
 	.set_uri     = output_gstreamer_set_uri,

--- a/src/output_module.h
+++ b/src/output_module.h
@@ -30,6 +30,7 @@ struct output_module {
         const char *shortname;
         const char *description;
 	int (*add_options)(int *argc, char **argv[]);
+	const char *(*version)(char *buffer, size_t len);
 
 	// Commands.
 	int (*init)(void);

--- a/src/output_module.h
+++ b/src/output_module.h
@@ -29,7 +29,7 @@
 struct output_module {
         const char *shortname;
         const char *description;
-	int (*add_options)(GOptionContext *ctx);
+	int (*add_options)(int *argc, char **argv[]);
 
 	// Commands.
 	int (*init)(void);

--- a/src/output_module.h
+++ b/src/output_module.h
@@ -34,6 +34,7 @@ struct output_module {
 
 	// Commands.
 	int (*init)(void);
+	int (*loop)(void);
 	void (*set_uri)(const char *uri, output_update_meta_cb_t meta_info);
 	void (*set_next_uri)(const char *uri);
 	int (*play)(output_transition_cb_t transition_callback);

--- a/src/output_module.h
+++ b/src/output_module.h
@@ -40,10 +40,10 @@ struct output_module {
 	int (*play)(output_transition_cb_t transition_callback);
 	int (*stop)(void);
 	int (*pause)(void);
-	int (*seek)(gint64 position_nanos);
+	int (*seek)(int64_t position_nanos);
 
 	// parameters
-	int (*get_position)(gint64 *track_duration, gint64 *track_pos);
+	int (*get_position)(int64_t *track_duration, int64_t *track_pos);
 	int (*get_volume)(float *);
 	int (*set_volume)(float);
 	int (*get_mute)(int *);

--- a/src/upnp_connmgr.c
+++ b/src/upnp_connmgr.c
@@ -186,7 +186,7 @@ static bool remove_mime_type(const char* mime_type)
 	return false;
 }
 
-static gint g_compare_mime_root(gconstpointer a, gconstpointer b)
+static int g_compare_mime_root(const void* a, const void* b)
 {
 	size_t aLen = strlen((const char*)a);
 	size_t bLen = strlen((const char*)b);
@@ -197,12 +197,12 @@ static gint g_compare_mime_root(gconstpointer a, gconstpointer b)
 	return strncmp((const char*) a, (const char*) b, min);
 }
 
-static void g_add_mime_type(gpointer data, gpointer user_data)
+static void g_add_mime_type(void* data, void* user_data)
 {
 	add_mime_type((const char*) data);
 }
 
-static void g_remove_mime_type(gpointer data, gpointer user_data)
+static void g_remove_mime_type(void* data, void* user_data)
 {
 	remove_mime_type((const char*) data);
 }

--- a/src/upnp_connmgr.c
+++ b/src/upnp_connmgr.c
@@ -57,6 +57,13 @@
 #define CONNMGR_CONTROL_URL "/upnp/control/renderconnmgr1"
 #define CONNMGR_EVENT_URL "/upnp/event/renderconnmgr1"
 
+typedef struct mime_type_filters_t
+{
+	GSList* allowed_roots;
+	GSList* removed_types;
+	GSList* added_types;
+} mime_type_filters_t;
+
 typedef enum {
 	CONNMGR_VAR_AAT_CONN_MGR,
 	CONNMGR_VAR_SINK_PROTO_INFO,

--- a/src/upnp_connmgr.h
+++ b/src/upnp_connmgr.h
@@ -24,15 +24,6 @@
 #ifndef _UPNP_CONNMGR_H
 #define _UPNP_CONNMGR_H
 
-#include <glib.h>
-
-typedef struct mime_type_filters_t
-{
-	GSList* allowed_roots;
-	GSList* removed_types;
-	GSList* added_types;
-} mime_type_filters_t;
-
 struct service *upnp_connmgr_get_service(void);
 int connmgr_init(const char* mime_filter);
 

--- a/src/upnp_device.c
+++ b/src/upnp_device.c
@@ -32,7 +32,6 @@
 #include <stdarg.h>
 #include <assert.h>
 #include <string.h>
-#include <glib.h>
 
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -414,7 +413,7 @@ static UPNP_CALLBACK(event_handler, EventType, event, userdata)
 	return 0;
 }
 
-static gboolean initialize_device(struct upnp_device_descriptor *device_def,
+static int initialize_device(struct upnp_device_descriptor *device_def,
 				  struct upnp_device *result_device,
 				  const char *ip_address,
 				  unsigned short port)

--- a/src/upnp_transport.c
+++ b/src/upnp_transport.c
@@ -36,8 +36,6 @@
 #include <string.h>
 #include <assert.h>
 
-#include <glib.h>
-
 #include <upnp.h>
 #include <ithread.h>
 
@@ -647,39 +645,39 @@ static int get_transport_settings(struct action_event *event)
 }
 
 // Print UPnP formatted time into given buffer. time given in nanoseconds.
-static int divide_leave_remainder(gint64 *val, gint64 divisor) {
+static int divide_leave_remainder(int64_t *val, int64_t divisor) {
 	int result = *val / divisor;
 	*val %= divisor;
 	return result;
 }
-static void print_upnp_time(char *result, size_t size, gint64 t) {
-	const gint64 one_sec = 1000000000LL;  // units are in nanoseconds.
+static void print_upnp_time(char *result, size_t size, int64_t t) {
+	const int64_t one_sec = 1000000000LL;  // units are in nanoseconds.
 	const int hour = divide_leave_remainder(&t, 3600LL * one_sec);
 	const int minute = divide_leave_remainder(&t, 60LL * one_sec);
 	const int second = divide_leave_remainder(&t, one_sec);
 	snprintf(result, size, "%d:%02d:%02d", hour, minute, second);
 }
 
-static gint64 parse_upnp_time(const char *time_string) {
+static int64_t parse_upnp_time(const char *time_string) {
 	int hour = 0;
 	int minute = 0;
 	int second = 0;
 	sscanf(time_string, "%d:%02d:%02d", &hour, &minute, &second);
-	const gint64 seconds = (hour * 3600 + minute * 60 + second);
-	const gint64 one_sec_unit = 1000000000LL;
+	const int64_t seconds = (hour * 3600 + minute * 60 + second);
+	const int64_t one_sec_unit = 1000000000LL;
 	return one_sec_unit * seconds;
 }
 
 // We constantly update the track time to event about it to our clients.
 static void *thread_update_track_time(void *userdata) {
 	(void)userdata;
-	const gint64 one_sec_unit = 1000000000LL;
+	const int64_t one_sec_unit = 1000000000LL;
 	char tbuf[32];
-	gint64 last_duration = -1, last_position = -1;
+	int64_t last_duration = -1, last_position = -1;
 	for (;;) {
 		usleep(500000);  // 500ms
 		service_lock();
-		gint64 duration, position;
+		int64_t duration, position;
 		const int pos_result = output_get_position(&duration, &position);
 		if (pos_result == 0) {
 			if (duration != last_duration) {
@@ -876,7 +874,7 @@ static int seek(struct action_event *event)
 	if (strcmp(unit, "REL_TIME") == 0) {
 		// This is the only thing we support right now.
 		const char *target = upnp_get_string(event, "Target");
-		gint64 nanos = parse_upnp_time(target);
+		int64_t nanos = parse_upnp_time(target);
 		service_lock();
 		if (output_seek(nanos) == 0) {
 			// TODO(hzeller): Seeking might take some time,

--- a/src/webserver.c
+++ b/src/webserver.c
@@ -268,14 +268,13 @@ static struct UpnpVirtualDirCallbacks virtual_dir_callbacks = {
 	webserver_close
 };
 
-gboolean webserver_register_callbacks(void) {
+int webserver_register_callbacks(void) {
   int rc = UpnpSetVirtualDirCallbacks(&virtual_dir_callbacks);
   if (UPNP_E_SUCCESS != rc) {
     Log_error("webserver", "UpnpSetVirtualDirCallbacks() Error: %s (%d)",
 	      UpnpGetErrorMessage(rc), rc);
-    return FALSE;
   }
-  return TRUE;
+  return (UPNP_E_SUCCESS == rc);
 }
 #else
 // With version 1.6.7 and above, the UPNP library maintainers made a questionable
@@ -288,8 +287,8 @@ gboolean webserver_register_callbacks(void) {
 // Assuming that they will go on with this broken idea and eventually remove
 // the support for the VirtualDirCallbacks in new major versions, we use the
 // newer (may I emphasize: questionable) API to register the callbacks.
-gboolean webserver_register_callbacks(void) {
-  gboolean result =
+int webserver_register_callbacks(void) {
+  int result =
     (UpnpVirtualDir_set_GetInfoCallback(webserver_get_info) == UPNP_E_SUCCESS
      && UpnpVirtualDir_set_OpenCallback(webserver_open) == UPNP_E_SUCCESS
      && UpnpVirtualDir_set_ReadCallback(webserver_read) == UPNP_E_SUCCESS

--- a/src/webserver.h
+++ b/src/webserver.h
@@ -24,10 +24,8 @@
 #ifndef _WEBSERVER_H
 #define _WEBSERVER_H
 
-#include <glib.h>
-
 // Start the webserver with the registered files.
-gboolean webserver_register_callbacks(void);
+int webserver_register_callbacks(void);
 
 int webserver_register_buf(const char *path, const char *contents,
                            const char *content_type);


### PR DESCRIPTION
This collection of patches remove all dependencies on glib except inside output_gstreamer.
The binary loses weight by 17ko without gstreamer and by 15ko with gstreamer.
It is also possible to integrate gmediarender on systems without glib, like distributions build with BuildRoot or Yocto.
This modification is targeted for embedded system like Raspberry Pi.
