### PR TITLE
Added network dependency for init.d script

### DIFF
--- a/scripts/init.d/gmediarenderer
+++ b/scripts/init.d/gmediarenderer
@@ -2,7 +2,7 @@
 
 ### BEGIN INIT INFO
 # Provides: gmediarender
-# Required-Start: $remote_fs $syslog $all 
+# Required-Start: $remote_fs $syslog $all $network
 # Required-Stop: $remote_fs $syslog
 # Default-Start: 2 3 4 5
 # Default-Stop: 0 1 6


### PR DESCRIPTION
In some cases the daemon would start before the network is available, in which case it won't start advertising on the network, so added the $network dependency in the init.d script