### PR TITLE
Fix: Ensure proper UTF-8 handling for renderer name

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -32,6 +32,7 @@
 #include <assert.h>
 #include <glib.h>
 #include <limits.h>
+#include <locale.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -219,6 +220,12 @@ int main(int argc, char **argv)
 {
 	int rc;
 	struct upnp_device_descriptor *upnp_renderer;
+
+	// According to the official GLib documentation (https://docs.gtk.org/glib/running.html#locale),
+	// many GLib interfaces rely on the application's current locale.
+	// Therefore, most applications using GLib should call setlocale(LC_ALL, "") to properly set up the locale,
+	// ensuring correct string handling, character encoding, and localization functionality.
+	setlocale(LC_ALL, "");
 
 #if !GLIB_CHECK_VERSION(2,32,0)
 	g_thread_init (NULL);  // Was necessary < glib 2.32, deprecated since.


### PR DESCRIPTION
When setting the renderer name to non-ASCII characters (such as Chinese),  gmediarender failed due to invalid byte sequence conversion. The issue was  identified in https://github.com/hzeller/gmrender-resurrect/issues/81, where  it was suggested that explicitly setting the locale in the main function  could resolve the problem.

This patch adds:
- `#include <locale.h>` to ensure locale handling is available.
- `setlocale(LC_ALL, "")` at the beginning of `main()` to use the system locale.

With this change, gmediarender correctly processes UTF-8 encoded renderer  names, preventing command line parsing errors.

Reference: https://github.com/hzeller/gmrender-resurrect/issues/81