### PR TITLE
Fix build failure with make --shuffle=reverse

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -18,14 +18,13 @@ gmediarender_SOURCES += \
 	output_gstreamer.c  output_gstreamer.h
 endif
 
-main.c : git-version.h
+BUILT_SOURCES = git-version.h
+EXTRA_DIST = git-version.h
 
-git-version.h: .FORCE
+git-version.h: $(wildcard $(top_srcdir)/.git/HEAD $(top_srcdir)/.git/refs/heads/*)
 	$(AM_V_GEN)(echo "#define GM_COMPILE_VERSION \"$(shell git describe 2>/dev/null || echo -n '0.3')\"" > $@-new; \
 	cmp -s $@ $@-new || cp $@-new $@; \
 	rm $@-new)
-
-.FORCE:
 
 AM_CPPFLAGS = $(GLIB_CFLAGS) $(GST_CFLAGS) $(LIBUPNP_CFLAGS) -DPKG_DATADIR=\"$(datadir)/gmediarender\"
 gmediarender_LDADD = $(GLIB_LIBS) $(GST_LIBS) $(LIBUPNP_LIBS)


### PR DESCRIPTION
(The issue has been reported in Debian in this bug: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1105332)

The generated Makefile is not safe against non-deterministic ordering of target prequisites.  Declaring BUILT_SOURCES will ensure that the file git-version.h will always be created.

EXTRA_DIST will make sure git_version.h is shipped when doing make dist in the generated tarball, so when issuing make dist within the git repo, this will get the correct value.

Finally, git-version.h will get as prerequisite some git files that will get an updated timestamp when a commit has happened, ensuring that the version file will be updated. (The .FORCE is not needed anymore due to this.)

The rule to update git.version.h could probably be simplified, as in the tarball situation the rule won't be executed

the rule for main.c is not needed, so this line can be removed.

(One missing bit is that the rule for git-version.h could probably stop regenerating the file if the git repo is not present, to avoid overwriting a "make dist" provided file)