### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,6 @@ You can reach me via <h.zeller@acm.org>.
 
 [orig-project]: http://gmrender.nongnu.org/
 [orig-cvs]:http://cvs.savannah.gnu.org/viewvc/gmrender/?root=gmrender
-[compat-wiki]: https://github.com/hzeller/gmrender-resurrect/wiki/Comptibility
+[compat-wiki]: https://github.com/hzeller/gmrender-resurrect/wiki/Compatibility
 [upnp-display]: https://github.com/hzeller/upnp-display
 [open-max-support]: https://github.com/hzeller/gmrender-resurrect/issues/33#issuecomment-23859699


### PR DESCRIPTION
I wanted to check the list of supported control points and eventually extend it, as suggested. After clicking the link to the compatibility page, it appeared that this was broken since introduced with https://github.com/hzeller/gmrender-resurrect/commit/6870ac294d860eafeabef652e5d1edc6340d1a0f.

Duplicate of #267 