### PR TITLE
Systemd service from Debian

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -59,7 +59,7 @@ PREFIX in the configure step).
 There is a sample init script in `scripts/init.d/gmediarenderer` that could be
 a good start if you install things on your system.
 
-A systemd unit file can be found in `dist-scripts/debian/gmrender-resurrect.service`.
+A systemd unit file can be found in `scripts/systemd/`.
 
 (To Linux distribution packagers: please let me know if you have some
 common changes that might be useful to have in upstream; other than that, just

--- a/scripts/systemd/README.md
+++ b/scripts/systemd/README.md
@@ -1,0 +1,26 @@
+# systemd service and wrapper
+
+This directory contains a systemd service file and a supplementary wrapper.
+
+The wrapper's job is to be able to configure the daemon at runtime, like the
+init.d script does: It calculates the UUID based on the MAC of the first network
+device and make a default user-friendly name for the renderer based on the hostname.
+
+The systemd service uses basic hardening provided by DynamicUser=yes
+
+## gmediarender.service
+
+This files should be copied to /etc/systemd/system/.
+
+## gmediarender-wrapper
+
+This file should be copied to /usr/libexec/gmediarender/
+
+It reads the configuration and will start gmediarender
+
+## gmediarender.conf
+
+This file should be copied to /etc/gmediarender/ and
+hosts the configuration of the renderer. 
+
+

--- a/scripts/systemd/gmediarender-wrapper
+++ b/scripts/systemd/gmediarender-wrapper
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -e
+
+CONF_SRC="/etc/gmediarender/gmediarender.conf"
+
+# setup defaults.
+UPNP_DEVICE_NAME="gmediarender on $(hostname)"
+INITIAL_VOLUME_DB=-10
+GS_SINK_PARAM="--gstout-audiosink=autodetect"
+GS_DEVICE_PARAM=""
+DAEMON_EXTRA_ARGS=""
+
+if [ -r "$CONF_SRC" ]; then
+    . "$CONF_SRC"
+fi
+
+if [ -z "$UPNP_UUID" ] ; then
+  UPNP_UUID=`ip link show | awk '/ether/ {print "salt:)-" $2}' | head -1 | md5sum | awk '{print $1}'`
+fi
+
+if [ -n "$ALSA_DEVICE" ] ; then
+        GS_SINK_PARAM="--gstout-audiosink=alsasink"
+        GS_DEVICE_PARAM="--gstout-audiodevice=$ALSA_DEVICE"
+fi
+
+if [ -n "$GS_AUDIOSINK" ] ; then
+  GS_SINK_PARAM="--gstout-audiosink=${GS_AUDIOSINK}"
+fi
+
+if [ -n "$GS_AUDIODEVICE" ] ; then
+  GS_DEVICE_PARAM="--gstout-audiodevice=${GS_AUDIODEVICE}"
+fi
+
+/usr/bin/gmediarender \
+    --logfile=stdout -f \
+    "$UPNP_DEVICE_NAME" \
+    -u "$UPNP_UUID" \
+    "$GS_SINK_PARAM" \
+    "$GS_DEVICE_PARAM" \
+    "--gstout-initial-volume-db=$INITIAL_VOLUME_DB" \
+    $DAEMON_EXTRA_ARGS
+

--- a/scripts/systemd/gmediarender.conf
+++ b/scripts/systemd/gmediarender.conf
@@ -1,0 +1,35 @@
+# Configuration for gmediarender
+
+# Device name as it will be advertised to and shown in the UPnP controller UI.
+# Some string that helps you recognize the player, e.g. "Livingroom Player"
+UPNP_DEVICE_NAME="gmediarender on $(hostname)"
+
+# UUID for the UPnP Media render. By default (if not set) it is derived from the
+# MAC of the first network device.
+#UPNP_UUID=
+
+# Initial volume in decibel. 0.0 is 'full volume', -10 correspondents to '75' on
+# the exported volume scale (Note, this does not change the ALSA volume, only
+# internal to gmrender. So make sure to leave the ALSA volume always to 100%).
+#INITIAL_VOLUME_DB=-10
+
+# If you explicitly choose a specific ALSA device here (find them with 'aplay -L'), then
+# gmediarenderer will use that ALSA device to play audio.
+# Otherwise, whatever default is configured for gstreamer for the '$DAEMON_USER' is
+# used.
+ALSA_DEVICE="sysdefault"
+#ALSA_DEVICE="iec958"
+
+# Defines the gstreamer audio sink to be used.
+# gst-inspect-1.0 | grep -i "sink" | grep -i "audio" gives a list.
+# if ALSA_DEVICE is defined, it will default to "alsasink", but
+# can be overridden here.
+#GS_AUDIOSINK=""
+
+# defines the audiodevice to be used.
+# if ALSA_DEVICE is defined, it will default to "$ALSA_DEVICE", but
+# can be overridden here.
+#GS_AUDIODEVICE=""
+
+# You can pass extra arguments to the daemon.
+# DAEMON_EXTRA_ARGS=""

--- a/scripts/systemd/gmediarender.service
+++ b/scripts/systemd/gmediarender.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=GMediaRender UPnP/DLNA renderer
+After=network-online.target local-fs.target
+Wants=network-online.target
+Documentation=man:gmediarender
+
+[Service]
+# Identity & Permissions
+DynamicUser=yes
+SupplementaryGroups=audio
+RuntimeDirectory=gmediarender
+PrivateDevices=no
+# Explicitly allow access to ALSA device nodes
+DeviceAllow=/dev/snd rwm
+DeviceAllow=/dev/dsp rwm
+DeviceAllow=char-alsa rw
+
+# This ensures that ALSA can find its own configuration files
+BindReadOnlyPaths=/usr/share/alsa /var/lib/alsa
+
+
+Environment=XDG_CACHE_HOME=/run/gmediarender
+Environment=XDG_CONFIG_HOME=/run/gmediarender
+
+# Generate Configuration
+ExecStart=/usr/libexec/gmediarender/gmediarender-wrapper
+
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
To fix Debian bug
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1039211, I've implemented a systemd service modeled after the init.d script:
- it will calculate the UUID based on the MAC of the network card
- by default if will give the renderer a user-friendly name based on the hostname.

There is also some cleanup, like remove the Debianism "/etc/default/" in favour of havin the config in /etc/gmediarender/gmediarender.conf.

The systemd service enables some hardening options, by enabling systemd's DynamicUser=yes.
